### PR TITLE
fix: correct copilot plugin install syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Recommended:
 
 ```bash
 copilot plugin marketplace add Azure/git-ape
-copilot plugin install Azure/git-ape
+copilot plugin install git-ape@git-ape
+```
+
+Verify the installation:
+
+```bash
+copilot plugin list   # Should show: git-ape@git-ape
 ```
 
 Manual option:


### PR DESCRIPTION
## Summary

Fix incorrect `copilot plugin install` syntax in README.md that causes silent installation failures.

## Problem

The README documents:
```bash
copilot plugin install Azure/git-ape
```

This uses the `owner/repo` format (direct repo install), **not** the `plugin@marketplace` format. The result is that the marketplace is registered but the plugin is never properly installed — agents and skills don't load.

## Fix

Changed to the correct `plugin@marketplace` syntax:
```bash
copilot plugin install git-ape@git-ape
```

Also added a verification step:
```bash
copilot plugin list   # Should show: git-ape@git-ape
```

## Context

- This is the public-repo counterpart of the fix already merged in [Azure/git-ape-private#58](https://github.com/Azure/git-ape-private/issues/58)
- Original issue: #10

Fixes #10