### PR TITLE
Update README with Copilot CLI installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ copilot plugin marketplace add Azure/git-ape
 copilot plugin install git-ape@git-ape
 copilot plugin list   # Should show: git-ape@git-ape
 ```
+```With Copilot CLI
+/plugin marketplace add https://github.com/Azure/git-ape
+/plugin install git-ape@git-ape
+/plugin list   # Should show: git-ape@git-ape
 
 #### Option C: Local development install
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ copilot plugin list   # Should show: git-ape@git-ape
 /plugin marketplace add https://github.com/Azure/git-ape
 /plugin install git-ape@git-ape
 /plugin list   # Should show: git-ape@git-ape
-
+```
 #### Option C: Local development install
 
 Clone this repository and register the local checkout as a VS Code plugin in `settings.json`:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ copilot plugin marketplace add Azure/git-ape
 copilot plugin install git-ape@git-ape
 copilot plugin list   # Should show: git-ape@git-ape
 ```
-```With Copilot CLI
+```Within Copilot CLI
 /plugin marketplace add https://github.com/Azure/git-ape
 /plugin install git-ape@git-ape
 /plugin list   # Should show: git-ape@git-ape


### PR DESCRIPTION
Added instructions for using Copilot CLI to install git-ape plugin.