### PR TITLE
fix(docs): use https redirect pages for VS Code settings badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Prerequisites: VS Code with GitHub Copilot enabled and the `chat.plugins.enabled
 
 1. Add the marketplace in your VS Code `settings.json`:
 
-   [![Open in VS Code](https://img.shields.io/badge/Open_Settings-VS_Code-007ACC?logo=visualstudiocode&logoColor=white)](vscode://settings/chat.plugins.marketplaces) [![Open in VS Code Insiders](https://img.shields.io/badge/Open_Settings-VS_Code_Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](vscode-insiders://settings/chat.plugins.marketplaces)
+   [![Open Settings in VS Code](https://img.shields.io/badge/Open_Settings-VS_Code-007ACC?logo=visualstudiocode&logoColor=white)](https://azure.github.io/git-ape/open-settings.html) [![Open Settings in VS Code Insiders](https://img.shields.io/badge/Open_Settings-VS_Code_Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](https://azure.github.io/git-ape/open-settings-insiders.html)
 
    ```jsonc
    "chat.plugins.marketplaces": [

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -35,6 +35,8 @@ Your organization must have the `chat.plugins.enabled` setting set to `true`. If
 
 1. Add the Git-Ape marketplace to your VS Code `settings.json`:
 
+   [![Open Settings in VS Code](https://img.shields.io/badge/Open_Settings-VS_Code-007ACC?logo=visualstudiocode&logoColor=white)](pathname:///open-settings.html) [![Open Settings in VS Code Insiders](https://img.shields.io/badge/Open_Settings-VS_Code_Insiders-24bfa5?logo=visualstudiocode&logoColor=white)](pathname:///open-settings-insiders.html)
+
    ```jsonc
    "chat.plugins.marketplaces": [
        "Azure/git-ape"

--- a/website/static/open-settings-insiders.html
+++ b/website/static/open-settings-insiders.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Open VS Code Insiders Settings — Git-Ape</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <meta http-equiv="refresh" content="0; url=vscode-insiders://settings/chat.plugins.marketplaces" />
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 640px; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #1f2328; }
+    code { background: #f6f8fa; padding: 0.15rem 0.35rem; border-radius: 4px; font-size: 0.95em; }
+    pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow: auto; }
+    a.button { display: inline-block; background: #24bfa5; color: white; padding: 0.5rem 1rem; border-radius: 6px; text-decoration: none; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>Opening VS Code Insiders settings…</h1>
+  <p>You should be redirected to VS Code Insiders and the <code>chat.plugins.marketplaces</code> setting in a moment.</p>
+  <p>If nothing happens, click the button below:</p>
+  <p><a class="button" href="vscode-insiders://settings/chat.plugins.marketplaces">Open in VS Code Insiders</a></p>
+  <h2>Manual setup</h2>
+  <p>If your browser cannot open <code>vscode-insiders://</code> links, add this to your VS Code Insiders <code>settings.json</code>:</p>
+  <pre><code>"chat.plugins.marketplaces": [
+    "Azure/git-ape"
+]</code></pre>
+  <p><a href="https://azure.github.io/git-ape/">← Back to Git-Ape docs</a></p>
+  <script>
+    setTimeout(function () {
+      window.location.href = "vscode-insiders://settings/chat.plugins.marketplaces";
+    }, 50);
+  </script>
+</body>
+</html>

--- a/website/static/open-settings.html
+++ b/website/static/open-settings.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Open VS Code Settings — Git-Ape</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <meta http-equiv="refresh" content="0; url=vscode://settings/chat.plugins.marketplaces" />
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 640px; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; color: #1f2328; }
+    code { background: #f6f8fa; padding: 0.15rem 0.35rem; border-radius: 4px; font-size: 0.95em; }
+    pre { background: #f6f8fa; padding: 1rem; border-radius: 6px; overflow: auto; }
+    a.button { display: inline-block; background: #007ACC; color: white; padding: 0.5rem 1rem; border-radius: 6px; text-decoration: none; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <h1>Opening VS Code settings…</h1>
+  <p>You should be redirected to VS Code and the <code>chat.plugins.marketplaces</code> setting in a moment.</p>
+  <p>If nothing happens, click the button below:</p>
+  <p><a class="button" href="vscode://settings/chat.plugins.marketplaces">Open in VS Code</a></p>
+  <h2>Manual setup</h2>
+  <p>If your browser cannot open <code>vscode://</code> links, add this to your VS Code <code>settings.json</code>:</p>
+  <pre><code>"chat.plugins.marketplaces": [
+    "Azure/git-ape"
+]</code></pre>
+  <p><a href="https://azure.github.io/git-ape/">← Back to Git-Ape docs</a></p>
+  <script>
+    // Fallback: trigger navigation programmatically as well
+    setTimeout(function () {
+      window.location.href = "vscode://settings/chat.plugins.marketplaces";
+    }, 50);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #41.

## Problem

The badges added in #41 use `vscode://` and `vscode-insiders://` URIs as their link targets:

```md
[![…](badge.svg)](vscode://settings/chat.plugins.marketplaces)
```

GitHub's markdown sanitizer only allows a limited set of URL schemes (`http`, `https`, `mailto`, `ftp`, `irc`, `git`, …). Custom schemes like `vscode://` are stripped from `href` attributes when the markdown is rendered to HTML.

The badge image is then left without an enclosing anchor. Clicking an unlinked image triggers GitHub's image lightbox, so the badge SVG opens **full-screen** instead of opening VS Code. This reproduces in:

- github.com (README and PR "Files changed" view)
- The VS Code GitHub Pull Requests extension (review file view)

## Fix

Point the badges at small static **HTTPS** redirect pages hosted on the Docusaurus site. HTTPS hrefs survive sanitization, and the redirect page meta-refreshes into the `vscode://` URI (with a JS fallback and a manual button).

### Changes

- **README.md** — badges link to `https://azure.github.io/git-ape/open-settings.html` and `…/open-settings-insiders.html`.
- **website/docs/getting-started/installation.md** — same two badges added using Docusaurus' `pathname:///` link prefix so the URL resolves to the static file at any `baseUrl` (works locally on `/` and in production on `/git-ape/`).
- **website/static/open-settings.html** — new redirect → `vscode://settings/chat.plugins.marketplaces`.
- **website/static/open-settings-insiders.html** — new redirect → `vscode-insiders://settings/chat.plugins.marketplaces`.

## Verification

- Built and ran Docusaurus locally; both badges render and click through to the redirect pages.
- README badges link to https URLs that survive GitHub's markdown sanitizer.
- Manual setup instructions remain on the redirect pages for users whose browsers cannot open `vscode://` URIs.
