### PR TITLE
feat(plugin): add marketplace settings and release pipelines

### DIFF
--- a/.github/copilot/settings.json
+++ b/.github/copilot/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://aka.ms/vscode-chat-customization-schema",
+  "extraKnownMarketplaces": {
+    "git-ape": {
+      "source": {
+        "source": "github",
+        "repo": "Azure/git-ape"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "git-ape@git-ape": true
+  }
+}

--- a/.github/workflows/git-ape-actionlint.yml
+++ b/.github/workflows/git-ape-actionlint.yml
@@ -1,0 +1,25 @@
+name: "Git-Ape: Workflow Lint"
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        run: |
+          set -euo pipefail
+          # Download the official actionlint binary into the workspace.
+          bash <(curl --silent --show-error --fail \
+            https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/.github/workflows/git-ape-plugin-version-check.yml
+++ b/.github/workflows/git-ape-plugin-version-check.yml
@@ -1,0 +1,144 @@
+name: "Git-Ape: Plugin Version Check"
+
+on:
+  pull_request:
+    paths:
+      - 'plugin.json'
+      - '.github/plugin/marketplace.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-version-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate plugin.json and marketplace.json versions match
+        id: check
+        run: |
+          set -euo pipefail
+
+          PLUGIN_JSON="plugin.json"
+          MARKETPLACE_JSON=".github/plugin/marketplace.json"
+
+          if [[ ! -f "$PLUGIN_JSON" ]]; then
+            echo "❌ $PLUGIN_JSON not found"
+            exit 1
+          fi
+          if [[ ! -f "$MARKETPLACE_JSON" ]]; then
+            echo "❌ $MARKETPLACE_JSON not found"
+            exit 1
+          fi
+
+          PLUGIN_NAME=$(jq -r '.name' "$PLUGIN_JSON")
+          PLUGIN_VERSION=$(jq -r '.version' "$PLUGIN_JSON")
+
+          # Marketplace has top-level metadata.version and per-plugin entry.version.
+          MKT_METADATA_VERSION=$(jq -r '.metadata.version // empty' "$MARKETPLACE_JSON")
+          MKT_ENTRY_VERSION=$(jq -r --arg name "$PLUGIN_NAME" \
+            '.plugins[] | select(.name == $name) | .version' "$MARKETPLACE_JSON")
+          MKT_ENTRY_NAME_FOUND=$(jq -r --arg name "$PLUGIN_NAME" \
+            '[.plugins[] | select(.name == $name)] | length' "$MARKETPLACE_JSON")
+
+          echo "plugin.json:           name=$PLUGIN_NAME version=$PLUGIN_VERSION"
+          echo "marketplace metadata:  version=$MKT_METADATA_VERSION"
+          echo "marketplace entry:     name=$PLUGIN_NAME version=$MKT_ENTRY_VERSION"
+
+          ERRORS=0
+
+          # 1. plugin name must use kebab-case (VS Code agent plugin requirement).
+          if [[ ! "$PLUGIN_NAME" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]; then
+            echo "❌ plugin.json name '$PLUGIN_NAME' is not valid kebab-case (lowercase letters, numbers, hyphens)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [[ ${#PLUGIN_NAME} -gt 64 ]]; then
+            echo "❌ plugin.json name '$PLUGIN_NAME' exceeds 64 character limit"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          # 2. plugin must be listed in marketplace.
+          if [[ "$MKT_ENTRY_NAME_FOUND" -eq 0 ]]; then
+            echo "❌ marketplace.json has no plugin entry with name '$PLUGIN_NAME'"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          # 3. Versions must match across all three locations.
+          if [[ -n "$MKT_ENTRY_VERSION" && "$PLUGIN_VERSION" != "$MKT_ENTRY_VERSION" ]]; then
+            echo "❌ Version drift: plugin.json=$PLUGIN_VERSION but marketplace plugin entry=$MKT_ENTRY_VERSION"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [[ -n "$MKT_METADATA_VERSION" && "$PLUGIN_VERSION" != "$MKT_METADATA_VERSION" ]]; then
+            echo "⚠️ Marketplace metadata version ($MKT_METADATA_VERSION) does not match plugin.json ($PLUGIN_VERSION)"
+            echo "   These can intentionally differ if the marketplace versions independently."
+          fi
+
+          # 4. Version must be a valid semver-ish string (M.m.p with optional pre-release).
+          if [[ ! "$PLUGIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "❌ plugin.json version '$PLUGIN_VERSION' is not valid semver (expected M.m.p[-pre])"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          if [[ "$ERRORS" -gt 0 ]]; then
+            echo ""
+            echo "Plugin version check failed with $ERRORS error(s)."
+            echo "Bump plugin.json and the matching .github/plugin/marketplace.json plugin entry in lockstep."
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ plugin.json and marketplace.json are in sync at version $PLUGIN_VERSION"
+
+      - name: Validate plugin paths exist
+        run: |
+          set -euo pipefail
+
+          PLUGIN_JSON="plugin.json"
+          AGENTS_PATH=$(jq -r '.agents // empty' "$PLUGIN_JSON")
+          SKILLS_PATH=$(jq -r '.skills // empty' "$PLUGIN_JSON")
+
+          ERRORS=0
+
+          if [[ -z "$AGENTS_PATH" ]]; then
+            echo "❌ plugin.json is missing the 'agents' path"
+            ERRORS=$((ERRORS + 1))
+          elif [[ ! -d "$AGENTS_PATH" ]]; then
+            echo "❌ Agents path '$AGENTS_PATH' (from plugin.json) does not exist"
+            ERRORS=$((ERRORS + 1))
+          else
+            AGENT_COUNT=$(find "$AGENTS_PATH" -maxdepth 2 -name '*.agent.md' -type f | wc -l | tr -d ' ')
+            if [[ "$AGENT_COUNT" -eq 0 ]]; then
+              echo "❌ Agents path '$AGENTS_PATH' contains no *.agent.md files"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "✅ Agents path '$AGENTS_PATH' contains $AGENT_COUNT agent file(s)"
+            fi
+          fi
+
+          if [[ -z "$SKILLS_PATH" ]]; then
+            echo "❌ plugin.json is missing the 'skills' path"
+            ERRORS=$((ERRORS + 1))
+          elif [[ ! -d "$SKILLS_PATH" ]]; then
+            echo "❌ Skills path '$SKILLS_PATH' (from plugin.json) does not exist"
+            ERRORS=$((ERRORS + 1))
+          else
+            SKILL_COUNT=$(find "$SKILLS_PATH" -mindepth 2 -maxdepth 2 -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+            if [[ "$SKILL_COUNT" -eq 0 ]]; then
+              echo "❌ Skills path '$SKILLS_PATH' contains no */SKILL.md files"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "✅ Skills path '$SKILLS_PATH' contains $SKILL_COUNT skill(s)"
+            fi
+          fi
+
+          if [[ "$ERRORS" -gt 0 ]]; then
+            echo ""
+            echo "Plugin path validation failed with $ERRORS error(s)."
+            echo "Update plugin.json 'agents' and 'skills' fields to match the repo layout."
+            exit 1
+          fi

--- a/.github/workflows/git-ape-release.yml
+++ b/.github/workflows/git-ape-release.yml
@@ -1,0 +1,325 @@
+name: "Git-Ape: Plugin Release"
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (without leading v, e.g. 0.1.0). Will create tag v<version>.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Prevent overlapping release runs that could push conflicting tags or commits.
+# Different tags/versions still queue rather than cancel — we never want to
+# abandon a release mid-flight.
+concurrency:
+  group: git-ape-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve target version
+        id: ver
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Tag push: github.ref = refs/tags/vX.Y.Z
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "❌ '$VERSION' is not valid semver"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Mark as prerelease if semver has a pre-release suffix (e.g. 0.1.0-rc.1).
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Resolved version: $VERSION (tag: v$VERSION)"
+
+      - name: Bump plugin.json and marketplace.json
+        id: bump
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          PLUGIN_JSON="plugin.json"
+          MARKETPLACE_JSON=".github/plugin/marketplace.json"
+          PLUGIN_NAME=$(jq -r '.name' "$PLUGIN_JSON")
+
+          OLD_PLUGIN_VERSION=$(jq -r '.version' "$PLUGIN_JSON")
+          OLD_MKT_VERSION=$(jq -r '.metadata.version' "$MARKETPLACE_JSON")
+          OLD_MKT_ENTRY_VERSION=$(jq -r --arg name "$PLUGIN_NAME" \
+            '.plugins[] | select(.name == $name) | .version' "$MARKETPLACE_JSON")
+
+          echo "Current versions:"
+          echo "  plugin.json:        $OLD_PLUGIN_VERSION"
+          echo "  marketplace.meta:   $OLD_MKT_VERSION"
+          echo "  marketplace.entry:  $OLD_MKT_ENTRY_VERSION"
+          echo "Target version:       $VERSION"
+
+          jq --arg v "$VERSION" '.version = $v' "$PLUGIN_JSON" > "$PLUGIN_JSON.tmp"
+          mv "$PLUGIN_JSON.tmp" "$PLUGIN_JSON"
+
+          jq --arg v "$VERSION" --arg name "$PLUGIN_NAME" '
+            .metadata.version = $v
+            | .plugins |= map(if .name == $name then .version = $v else . end)
+          ' "$MARKETPLACE_JSON" > "$MARKETPLACE_JSON.tmp"
+          mv "$MARKETPLACE_JSON.tmp" "$MARKETPLACE_JSON"
+
+          if git diff --quiet plugin.json .github/plugin/marketplace.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit version bump (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch' && steps.bump.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugin.json .github/plugin/marketplace.json
+          git commit -m "chore(release): bump plugin to v$VERSION"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "$TAG"
+
+      - name: Generate release notes
+        id: notes
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || echo "")
+
+          # Collect commits grouped by conventional-commit type
+          if [[ -n "$PREV_TAG" ]]; then
+            RANGE="$PREV_TAG..$TAG"
+          else
+            RANGE="$TAG"
+          fi
+
+          declare -A SECTIONS
+          SECTIONS=(
+            [feat]=""
+            [fix]=""
+            [docs]=""
+            [ci]=""
+            [chore]=""
+            [refactor]=""
+            [perf]=""
+            [test]=""
+            [other]=""
+          )
+
+          SECTION_TITLES=(
+            [feat]="Features"
+            [fix]="Bug Fixes"
+            [docs]="Documentation"
+            [ci]="CI/CD"
+            [chore]="Chores"
+            [refactor]="Refactoring"
+            [perf]="Performance"
+            [test]="Tests"
+            [other]="Other Changes"
+          )
+
+          while IFS= read -r line; do
+            hash="${line%% *}"
+            msg="${line#* }"
+
+            # Parse conventional commit: type(scope): description  OR  type: description
+            if [[ "$msg" =~ ^([a-zA-Z]+)(\(.*\))?!?:\ (.+)$ ]]; then
+              type="${BASH_REMATCH[1],,}"  # lowercase
+              scope="${BASH_REMATCH[2]}"
+              desc="${BASH_REMATCH[3]}"
+              scope="${scope#(}"
+              scope="${scope%)}"
+
+              if [[ -z "${SECTIONS[$type]+_}" ]]; then
+                type="other"
+              fi
+
+              if [[ -n "$scope" ]]; then
+                SECTIONS[$type]+="- **${scope}:** ${desc} (\`${hash}\`)"$'\n'
+              else
+                SECTIONS[$type]+="- ${desc} (\`${hash}\`)"$'\n'
+              fi
+            else
+              SECTIONS[other]+="- ${msg} (\`${hash}\`)"$'\n'
+            fi
+          done < <(git log --pretty=format:'%h %s' "$RANGE" | head -200)
+
+          # Build the release notes file
+          {
+            echo "## Git-Ape $TAG"
+            echo
+            if [[ -n "$PREV_TAG" ]]; then
+              echo "Changes since [$PREV_TAG](https://github.com/${{ github.repository }}/releases/tag/$PREV_TAG):"
+            else
+              echo "Initial tagged release."
+            fi
+            echo
+
+            # Emit sections in display order
+            for type in feat fix perf refactor docs ci test chore other; do
+              if [[ -n "${SECTIONS[$type]}" ]]; then
+                echo "### ${SECTION_TITLES[$type]}"
+                echo
+                echo -n "${SECTIONS[$type]}"
+                echo
+              fi
+            done
+
+            echo "## Install"
+            echo
+            echo '### VS Code'
+            echo
+            echo '```jsonc'
+            echo '"chat.plugins.marketplaces": ["Azure/git-ape"]'
+            echo '```'
+            echo
+            # shellcheck disable=SC2016
+            echo 'Then install **git-ape** from the `@agentPlugins` Extensions view.'
+            echo
+            echo '### Copilot CLI'
+            echo
+            echo '```bash'
+            echo 'copilot plugin marketplace add Azure/git-ape'
+            echo 'copilot plugin install git-ape@git-ape'
+            echo '```'
+          } > release-notes.md
+
+          {
+            echo 'notes<<EOF'
+            cat release-notes.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          PRERELEASE: ${{ steps.ver.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          PRERELEASE_FLAG=""
+          if [[ "$PRERELEASE" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+            echo "Marking $TAG as a prerelease."
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; updating notes."
+            # shellcheck disable=SC2086
+            gh release edit "$TAG" --notes-file release-notes.md $PRERELEASE_FLAG
+          else
+            # shellcheck disable=SC2086
+            gh release create "$TAG" \
+              --title "Git-Ape $TAG" \
+              --notes-file release-notes.md \
+              $PRERELEASE_FLAG
+          fi
+
+      - name: Update CHANGELOG.md on main
+        if: steps.ver.outputs.prerelease == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Always work against the tip of main so the changelog stays current,
+          # even when this run was triggered by a tag push from an older commit.
+          git fetch origin main
+          git checkout -B changelog-update origin/main
+
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Strip the heading + install footer from release-notes.md to get just
+          # the entry body. release-notes.md format:
+          #   ## Git-Ape vX.Y.Z
+          #   <body>
+          #   ## Install
+          #   ...
+          ENTRY_BODY=$(awk '
+            /^## Install$/ { exit }
+            /^## Git-Ape / { next }
+            { print }
+          ' release-notes.md | sed -e 's/[[:space:]]*$//' | awk 'NF || p { p=1; print }')
+
+          NEW_ENTRY=$(printf '## [%s] - %s\n\n%s\n' "$VERSION" "$DATE" "$ENTRY_BODY")
+
+          if [[ -f CHANGELOG.md ]]; then
+            # Insert new entry below the top-level header, preserving existing content.
+            awk -v entry="$NEW_ENTRY" '
+              BEGIN { inserted = 0 }
+              {
+                print
+                if (!inserted && /^# /) {
+                  print ""
+                  print entry
+                  inserted = 1
+                }
+              }
+            ' CHANGELOG.md > CHANGELOG.md.tmp
+            mv CHANGELOG.md.tmp CHANGELOG.md
+          else
+            {
+              echo "# Changelog"
+              echo
+              echo "All notable changes to this project are documented here."
+              echo "This project follows [Semantic Versioning](https://semver.org/)."
+              echo
+              echo "$NEW_ENTRY"
+            } > CHANGELOG.md
+          fi
+
+          if git diff --quiet CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged; skipping commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs(changelog): add entry for $TAG"
+
+          # Push directly to main. If the push fails (someone else moved main),
+          # fall back to opening a PR so the changelog still lands.
+          if ! git push origin HEAD:main; then
+            echo "Direct push to main rejected; opening a PR instead."
+            BRANCH="changelog/${TAG}"
+            git push origin "HEAD:$BRANCH"
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "docs(changelog): add entry for $TAG" \
+              --body "Automated changelog update for [$TAG](https://github.com/${{ github.repository }}/releases/tag/$TAG)."
+          fi

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -521,12 +521,12 @@ function generateReferenceDocs() {
     const content = `---
 title: "plugin.json Reference"
 sidebar_label: "plugin.json"
-description: "Git-Ape Copilot CLI plugin manifest"
+description: "Git-Ape plugin manifest (VS Code agent plugin and Copilot CLI plugin)"
 ---
 
 # plugin.json
 
-The plugin manifest defines the Git-Ape Copilot CLI plugin metadata.
+The plugin manifest defines the Git-Ape plugin metadata. The same manifest is consumed by both the [VS Code agent plugin](https://code.visualstudio.com/docs/copilot/customization/agent-plugins) loader and the [GitHub Copilot CLI plugin](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) loader — no separate config is required.
 
 ## Current Configuration
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -87,6 +87,8 @@ You should see the Git-Ape orchestrator respond. If it does not, reload the VS C
 
 You have Git-Ape installed. Here is the recommended path depending on what you want to do:
 
+- [VS Code vs Copilot CLI](./vscode-vs-cli) — feature parity and when to pick which surface
+
 ```mermaid
 flowchart TD
     A["Git-Ape installed<br/>(VS Code or CLI)"] --> B{"What do you want to do?"}

--- a/website/docs/getting-started/onboarding.md
+++ b/website/docs/getting-started/onboarding.md
@@ -149,6 +149,10 @@ Follow these steps if you want to run each command yourself or need to understan
 Run `/prereq-check` in Copilot Chat to validate tools and auth sessions automatically.
 :::
 
+:::info[VS Code agent plugin requirement]
+Git-Ape ships as a [VS Code agent plugin](https://code.visualstudio.com/docs/copilot/customization/agent-plugins) (and as a Copilot CLI plugin). The VS Code surface is gated by the **`chat.plugins.enabled`** setting, which is **managed at the organization level**. If contributors install the plugin but `@git-ape` and the Git-Ape skills do not appear in Copilot Chat, ask your GitHub Copilot administrator to enable agent plugins for your organization. The Copilot CLI surface is not affected by this setting.
+:::
+
 <details>
 <summary><strong>Install commands by platform</strong></summary>
 

--- a/website/docs/getting-started/vscode-vs-cli.md
+++ b/website/docs/getting-started/vscode-vs-cli.md
@@ -1,0 +1,77 @@
+---
+title: "VS Code vs Copilot CLI"
+sidebar_label: "VS Code vs CLI"
+sidebar_position: 5
+description: "How Git-Ape behaves across the VS Code agent plugin and Copilot CLI surfaces"
+---
+
+# VS Code vs Copilot CLI
+
+Git-Ape ships as a single cross-tool plugin. The same `plugin.json` manifest at the repo root is loaded by both the [VS Code agent plugin](https://code.visualstudio.com/docs/copilot/customization/agent-plugins) system and the [GitHub Copilot CLI](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference). You don't need to maintain two copies — pick whichever surface you prefer.
+
+## Feature parity
+
+| Capability | VS Code agent plugin | Copilot CLI |
+|---|---|---|
+| `@git-ape` and other agents | ✅ Available in Copilot Chat | ✅ Available as agent participants |
+| Slash commands (`/prereq-check`, `/azure-security-analyzer`, …) | ✅ Surface in Chat command picker | ✅ Available via `/` in CLI |
+| Skills auto-loading | ✅ Listed under **Configure Skills** | ✅ Listed via `copilot skill list` |
+| MCP servers | ✅ Auto-started, listed in **MCP: List Servers** | ✅ Started by CLI on session start |
+| Hooks (`SessionStart`, `PreToolUse`, …) | ✅ Run alongside workspace hooks | ✅ Run alongside CLI hooks |
+| Marketplace install | ✅ `chat.plugins.marketplaces` | ✅ `copilot plugin marketplace add` |
+| Install from source | ✅ **Chat: Install Plugin From Source** | ✅ `copilot plugin install <git-url>` |
+| Local dev install | ✅ `chat.pluginLocations` | ✅ Local clone + plugin link |
+| Per-workspace enable/disable | ✅ Extensions view + Chat Customizations editor | ✅ Per-project plugin config |
+| Workspace recommendations | ✅ `.github/copilot/settings.json` (this repo) | ✅ Same file |
+| Update notifications | ✅ Driven by `version` in `plugin.json` | ✅ Driven by `version` in `plugin.json` |
+
+## When to use which
+
+**Use the VS Code agent plugin when you want:**
+
+- An interactive, GUI-driven deployment loop (`@git-ape deploy a Function App`).
+- Inline review of generated ARM templates and architecture diagrams.
+- Easy enable/disable per workspace from the Extensions view.
+
+**Use the Copilot CLI when you want:**
+
+- A scriptable, terminal-first workflow (CI runners, headless dev containers, Codespaces over SSH).
+- To compose Git-Ape with shell pipelines and existing CLI tooling.
+- A consistent experience across machines that may not have VS Code installed.
+
+Both modes share the same security gates, cost estimator, and deployment state under `.azure/deployments/` — switching between them on the same repo is safe.
+
+## Workspace recommendation
+
+This repository ships a workspace recommendation at [.github/copilot/settings.json](https://github.com/Azure/git-ape/blob/main/.github/copilot/settings.json) so contributors who open it in VS Code with `chat.plugins.enabled: true` get prompted to install Git-Ape automatically:
+
+```jsonc
+{
+  "extraKnownMarketplaces": {
+    "git-ape": {
+      "source": { "source": "github", "repo": "Azure/git-ape" }
+    }
+  },
+  "enabledPlugins": {
+    "git-ape@git-ape": true
+  }
+}
+```
+
+The same file is honored by the Copilot CLI when running inside the workspace.
+
+## Cross-tool authoring rules
+
+If you fork Git-Ape or build a similar plugin, keep the manifest cross-tool compatible:
+
+- Place `plugin.json` at the repo root (VS Code also accepts `.plugin/plugin.json`, `.github/plugin/plugin.json`, or `.claude-plugin/plugin.json`).
+- Use a plain kebab-case `name` (no `owner/repo` prefix). VS Code silently skips invalid names.
+- Skill `name` fields in `SKILL.md` frontmatter must match their directory name and be plain kebab-case.
+- Bump `version` in both `plugin.json` and `marketplace.json` when publishing changes — VS Code's update check uses these fields.
+
+## Related
+
+- [Installation](./installation) — full install paths for both surfaces
+- [Plugin manifest reference](../reference/plugin-json) — current `plugin.json` contents
+- [VS Code agent plugin docs](https://code.visualstudio.com/docs/copilot/customization/agent-plugins)
+- [Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)

--- a/website/docs/reference/plugin-json.md
+++ b/website/docs/reference/plugin-json.md
@@ -1,7 +1,7 @@
 ---
 title: "plugin.json Reference"
 sidebar_label: "plugin.json"
-description: "Git-Ape Copilot CLI plugin manifest"
+description: "Git-Ape plugin manifest (VS Code agent plugin and Copilot CLI plugin)"
 ---
 
 <!-- AUTO-GENERATED — DO NOT EDIT. Source: plugin.json -->
@@ -9,7 +9,7 @@ description: "Git-Ape Copilot CLI plugin manifest"
 
 # plugin.json
 
-The plugin manifest defines the Git-Ape Copilot CLI plugin metadata.
+The plugin manifest defines the Git-Ape plugin metadata. The same manifest is consumed by both the [VS Code agent plugin](https://code.visualstudio.com/docs/copilot/customization/agent-plugins) loader and the [GitHub Copilot CLI plugin](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) loader — no separate config is required.
 
 ## Current Configuration
 


### PR DESCRIPTION
## Summary

Adds plugin marketplace configuration and the release/CI pipelines that the public `Azure/git-ape` repo currently lacks.

Inspired by `Azure/git-ape-private` PRs #98, #99 and #100, adapted for this public repo.

## Changes

### Plugin settings

- **`.github/copilot/settings.json`** — workspace setting that recommends installing the `git-ape` plugin from the `Azure/git-ape` marketplace, so contributors and users get the right plugin offered automatically.

### Release pipeline (`.github/workflows/git-ape-release.yml`)

Tag-driven (`v*.*.*`) or `workflow_dispatch`-driven release pipeline.

- Validates semver, bumps `plugin.json` + `.github/plugin/marketplace.json` with `jq`.
- Generates a **conventional-commit-grouped changelog** with sections for `feat / fix / perf / refactor / docs / ci / test / chore / other`.
- Creates the GitHub release and **prepends** the notes to `CHANGELOG.md` on `main` (with a PR fallback when direct push is rejected by branch protection).
- Auto-detects pre-release versions (any semver containing `-`) and passes `--prerelease` to `gh release create`. The `CHANGELOG.md` update step is gated to non-prereleases.
- Top-level `concurrency` block scoped per `github.ref` with `cancel-in-progress: false` — releases are never abandoned mid-flight.

### PR checks

- **`git-ape-plugin-version-check.yml`** — runs on PRs that touch `plugin.json` or `marketplace.json`. Validates plugin name (kebab-case), semver, and that the version is identical between `plugin.json` and the matching `marketplace.json` plugin entry. Also validates that the configured `agents` / `skills` paths exist and contain the expected `*.agent.md` / `*/SKILL.md` files.
- **`git-ape-actionlint.yml`** — runs `actionlint` (with embedded `shellcheck`) on every PR that touches `.github/workflows/**` or `.github/actions/**`.

### Docs

- New page **`website/docs/getting-started/vscode-vs-cli.md`** — feature parity table between VS Code and Copilot CLI installations.
- `installation.md` — adds a link to the new page.
- `onboarding.md` — adds a `:::info` callout clarifying the VS Code agent plugin requirement after the `/prereq-check` tip.
- `reference/plugin-json.md` and `scripts/generate-docs.js` — minor description tweaks.

## Versioning

The first release this pipeline targets is **`v0.0.1`** (matches the current `plugin.json` and `marketplace.json` versions). After this PR is merged, a release can be cut either by:

- **Workflow dispatch** (recommended for the first cut): Actions → *Git-Ape: Plugin Release* → Run workflow on `main` with version `0.0.1`.
- Or **tag push**: `git tag v0.0.1 && git push origin v0.0.1`.

For the very first run the workflow will print *"Initial tagged release."* in the notes followed by all conventional commits since the start of the repo grouped by type.

## Validation

- All three workflows pass `actionlint -color` cleanly (no errors, no shellcheck warnings).
- All JSON files validated with `python3 -m json.tool`.
- All version fields aligned at `0.0.1` across `plugin.json`, `marketplace.json` (metadata + plugin entry), and `website/docs/reference/plugin-json.md` (verified via `jq`).

## Notes for reviewers

- Direct push from the release workflow uses `${{ secrets.GITHUB_TOKEN }}`. If `main` has branch protection that rejects bot pushes, the `CHANGELOG.md` step automatically falls back to opening a PR.
- Workflow-dispatch path also pushes a version-bump commit to `main`. If branch protection blocks that too, we can add a similar PR fallback in a follow-up — happy to do that as a separate PR if reviewers prefer.
