### PR TITLE
fix(release): declare SECTION_TITLES as associative array

### DIFF
--- a/.github/workflows/git-ape-release.yml
+++ b/.github/workflows/git-ape-release.yml
@@ -124,8 +124,7 @@ jobs:
             RANGE="$TAG"
           fi
 
-          declare -A SECTIONS
-          SECTIONS=(
+          declare -A SECTIONS=(
             [feat]=""
             [fix]=""
             [docs]=""
@@ -137,7 +136,7 @@ jobs:
             [other]=""
           )
 
-          SECTION_TITLES=(
+          declare -A SECTION_TITLES=(
             [feat]="Features"
             [fix]="Bug Fixes"
             [docs]="Documentation"

--- a/.github/workflows/git-ape-release.yml
+++ b/.github/workflows/git-ape-release.yml
@@ -115,13 +115,25 @@ jobs:
           TAG: ${{ steps.ver.outputs.tag }}
         run: |
           set -euo pipefail
-          PREV_TAG=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || echo "")
+
+          # Use the tag as the tip of the range when it exists as a ref. On
+          # workflow_dispatch with versions already aligned, the prior
+          # "Commit version bump" step is skipped, so the tag does not yet
+          # exist locally — fall back to HEAD so git log still walks the
+          # right commits.
+          if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
+            TIP="$TAG"
+          else
+            TIP="HEAD"
+          fi
+
+          PREV_TAG=$(git describe --tags --abbrev=0 "${TIP}^" 2>/dev/null || echo "")
 
           # Collect commits grouped by conventional-commit type
           if [[ -n "$PREV_TAG" ]]; then
-            RANGE="$PREV_TAG..$TAG"
+            RANGE="${PREV_TAG}..${TIP}"
           else
-            RANGE="$TAG"
+            RANGE="$TIP"
           fi
 
           declare -A SECTIONS=(


### PR DESCRIPTION
## Summary

Fixes the failure in [run #25362438095](https://github.com/Azure/git-ape/actions/runs/25362438095) and a second latent bug discovered when re-running the workflow locally with [`act`](https://github.com/nektos/act).

## Bug 1 — `feat: unbound variable`

In the `Generate release notes` step, `SECTION_TITLES` was declared without `declare -A`:

```bash
SECTION_TITLES=(
  [feat]="Features"
  ...
)
```

Without `declare -A`, bash treats this as an **indexed array** assignment, so the keys `[feat]`, `[fix]` etc. are evaluated as **arithmetic expressions**. Under `set -u`, the lookup of unset names like `feat` fails with `unbound variable` and the script exits before any release notes are written.

**Fix:** Add `declare -A` to `SECTION_TITLES`. Also collapsed `SECTIONS` into a single `declare -A SECTIONS=(...)` for symmetry.

## Bug 2 — empty changelog on `workflow_dispatch` (caught locally with `act`)

After Bug 1 was fixed, running the workflow locally surfaced a second issue:

```
fatal: ambiguous argument 'v0.0.1': unknown revision or path not in the working tree
```

On `workflow_dispatch` with versions already aligned, `bump.outputs.changed == 'false'`, so the `Commit version bump` step is skipped — meaning the tag is **never created locally**. The release-notes step then ran `git log v0.0.1` against a non-existent ref, silently producing release notes with an empty changelog (just title + install footer).

This would have shipped a vacuous v0.0.1 release without anyone noticing in CI, because:

- `git log` runs inside process substitution (`< <(git log ...)`), which doesn't propagate `pipefail`
- `git describe` already had a `|| echo ""` fallback, masking the missing ref

**Fix:** Probe the ref with `git rev-parse --verify` and fall back to `HEAD` when the tag does not yet exist:

```bash
if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
  TIP="$TAG"
else
  TIP="HEAD"
fi
```

## Verification

### Bug 1 — bash repro

Reproduced locally on `bash 5.3.9` (homebrew) — same major.minor as the GitHub Actions runner:

| Form | Result |
|---|---|
| Before (no `declare -A` on `SECTION_TITLES`) | `feat: unbound variable` — exits 1 |
| After (`declare -A SECTION_TITLES=(...)`) | Parses sample `feat(plugin): ...` commit and emits `### Features` with the formatted bullet |

### Bug 2 — `act` end-to-end

Re-ran the full workflow locally with `act`:

```bash
act workflow_dispatch -W .github/workflows/git-ape-release.yml \
  -e event.json -s GITHUB_TOKEN=... \
  -P ubuntu-latest=catthehacker/ubuntu:act-latest
```

Before fix: `Generate release notes` succeeds but emits empty changelog.
After fix: full conventional-commit-grouped changelog walking from the first commit through HEAD, with sections for **Features**, **Bug Fixes**, **Documentation**, **Other Changes**, etc.

Excerpt from the local `act` run on the fixed branch:

```
## Git-Ape v0.0.1

Initial tagged release.

### Features

- **plugin:** add marketplace settings and release pipelines (`597dd24`)

### Bug Fixes

- **release:** declare SECTION_TITLES as associative array (`6ce7ac9`)
- **website:** keep diagram top reachable when zoomed (`418ea7f`)
...
```

The `Create GitHub release` step does fail in `act` with `gh: command not found`, but that is a known `act` limitation (no `gh` CLI in the container). It is unrelated to the fix and runs fine on real GitHub-hosted runners.

`actionlint -color .github/workflows/git-ape-release.yml` is clean.

## Next step

After merge, re-run **Actions → Git-Ape: Plugin Release → workflow_dispatch** with version `0.0.1` to cut the first release.
