### PR TITLE
feat: deploy Python Function App (dev/eastus)

### DIFF
--- a/.azure/deployments/deploy-20260512-082853/architecture.md
+++ b/.azure/deployments/deploy-20260512-082853/architecture.md
@@ -1,0 +1,54 @@
+# Architecture: Python Function App (`deploy-20260512-082853`)
+
+## Resource Topology
+
+```mermaid
+graph TD
+    subgraph "Subscription-Level Deployment"
+        RG["📦 rg-pyapi-dev-eastus<br/>Resource Group"]
+    end
+
+    subgraph RG_CONTENTS ["rg-pyapi-dev-eastus"]
+        LOG["📊 log-pyapi-dev-eastus<br/>Log Analytics Workspace<br/>PerGB2018 / 30d retention"]
+        APPI["🔍 appi-pyapi-dev-eastus<br/>Application Insights<br/>Web / Workspace-based"]
+        ST["💾 stpyapidev{unique}<br/>Storage Account<br/>StorageV2 / Standard_LRS<br/>No shared key access"]
+        ASP["⚙️ asp-pyapi-dev-eastus<br/>App Service Plan<br/>Linux / Y1 Consumption"]
+        FUNC["⚡ func-pyapi-dev-eastus<br/>Function App<br/>Python 3.11 / Functions v4<br/>System Managed Identity"]
+    end
+
+    RG --> LOG
+    RG --> ST
+    LOG --> APPI
+    APPI --> FUNC
+    ST --> FUNC
+    ASP --> FUNC
+
+    FUNC -->|"🔑 Storage Blob Data Owner"| ST
+    FUNC -->|"🔑 Storage Account Contributor"| ST
+    FUNC -->|"📡 Connection String"| APPI
+
+    style RG fill:#e1f5fe
+    style FUNC fill:#fff3e0
+    style ST fill:#e8f5e9
+    style APPI fill:#fce4ec
+    style LOG fill:#f3e5f5
+    style ASP fill:#fff8e1
+```
+
+## Resource Inventory
+
+| # | Resource | Type | SKU | Region |
+|---|----------|------|-----|--------|
+| 1 | `rg-pyapi-dev-eastus` | Resource Group | — | East US |
+| 2 | `log-pyapi-dev-eastus` | Log Analytics Workspace | PerGB2018 | East US |
+| 3 | `appi-pyapi-dev-eastus` | Application Insights | Workspace-based | East US |
+| 4 | `stpyapidev{unique}` | Storage Account | Standard_LRS | East US |
+| 5 | `asp-pyapi-dev-eastus` | App Service Plan | Y1 (Consumption) | East US |
+| 6 | `func-pyapi-dev-eastus` | Function App | Python 3.11 / v4 | East US |
+
+## Data Flow
+
+1. **HTTP requests** → Function App (HTTPS-only, TLS 1.2+)
+2. **Function App** → Storage Account (identity-based, RBAC — no connection strings)
+3. **Function App** → App Insights (telemetry via connection string)
+4. **App Insights** → Log Analytics (workspace-linked)

--- a/.azure/deployments/deploy-20260512-082853/metadata.json
+++ b/.azure/deployments/deploy-20260512-082853/metadata.json
@@ -1,0 +1,17 @@
+{
+  "deploymentId": "deploy-20260512-082853",
+  "type": "new",
+  "status": "pending",
+  "createdAt": "2026-05-12T08:28:53Z",
+  "createdBy": "git-ape-agent",
+  "project": "pyapi",
+  "environment": "dev",
+  "region": "eastus",
+  "securityGate": "PASSED",
+  "tags": {
+    "Environment": "dev",
+    "Project": "pyapi",
+    "ManagedBy": "git-ape-agent",
+    "CreatedDate": "2026-05-12"
+  }
+}

--- a/.azure/deployments/deploy-20260512-082853/parameters.json
+++ b/.azure/deployments/deploy-20260512-082853/parameters.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "project": {
+      "value": "pyapi"
+    },
+    "environment": {
+      "value": "dev"
+    },
+    "location": {
+      "value": "eastus"
+    },
+    "pythonVersion": {
+      "value": "3.11"
+    }
+  }
+}

--- a/.azure/deployments/deploy-20260512-082853/requirements.json
+++ b/.azure/deployments/deploy-20260512-082853/requirements.json
@@ -1,0 +1,39 @@
+{
+  "deploymentId": "deploy-20260512-082853",
+  "timestamp": "2026-05-12T08:28:53Z",
+  "resourceType": "Azure Function App",
+  "project": "pyapi",
+  "environment": "dev",
+  "region": "eastus",
+  "runtime": {
+    "language": "python",
+    "version": "3.11"
+  },
+  "hostingPlan": {
+    "type": "Consumption",
+    "sku": "Y1",
+    "os": "Linux"
+  },
+  "resources": [
+    "Microsoft.Resources/resourceGroups",
+    "Microsoft.Storage/storageAccounts",
+    "Microsoft.Web/serverfarms",
+    "Microsoft.Web/sites",
+    "Microsoft.Insights/components",
+    "Microsoft.OperationalInsights/workspaces"
+  ],
+  "security": {
+    "identity": "SystemAssigned",
+    "httpsOnly": true,
+    "minTlsVersion": "1.2",
+    "ftpsState": "Disabled",
+    "storageAccess": "identity-based",
+    "allowSharedKeyAccess": false
+  },
+  "tags": {
+    "Environment": "dev",
+    "Project": "pyapi",
+    "ManagedBy": "git-ape-agent",
+    "CreatedDate": "2026-05-12"
+  }
+}

--- a/.azure/deployments/deploy-20260512-082853/security-analysis.md
+++ b/.azure/deployments/deploy-20260512-082853/security-analysis.md
@@ -1,0 +1,58 @@
+# Security Analysis: `deploy-20260512-082853`
+
+## Security Gate: 🟢 PASSED
+
+All 🔴 Critical and 🟠 High checks pass. Deployment may proceed.
+
+---
+
+## Function App (`func-pyapi-dev-eastus`)
+
+| Check | Severity | Status | Evidence | Notes |
+|-------|----------|--------|----------|-------|
+| HTTPS-only | 🔴 Critical | ✅ Applied | `properties.httpsOnly: true` | Explicitly set in template |
+| Minimum TLS 1.2 | 🔴 Critical | ✅ Applied | `siteConfig.minTlsVersion: "1.2"` | Explicitly set |
+| FTP disabled | 🟠 High | ✅ Applied | `siteConfig.ftpsState: "Disabled"` | No FTP/FTPS access |
+| Managed identity | 🟠 High | ✅ Applied | `identity.type: "SystemAssigned"` | System-assigned MI enabled |
+| Identity-based storage | 🟠 High | ✅ Applied | `AzureWebJobsStorage__accountName` app setting | No connection string used |
+| HTTP/2 enabled | 🟡 Medium | ✅ Applied | `siteConfig.http20Enabled: true` | Performance + security |
+| Run from package | 🟡 Medium | ✅ Applied | `WEBSITE_RUN_FROM_PACKAGE: "1"` | Read-only filesystem protection |
+
+## Storage Account (`stpyapidev{unique}`)
+
+| Check | Severity | Status | Evidence | Notes |
+|-------|----------|--------|----------|-------|
+| HTTPS-only traffic | 🔴 Critical | ✅ Applied | `properties.supportsHttpsTrafficOnly: true` | Explicitly set |
+| Minimum TLS 1.2 | 🔴 Critical | ✅ Applied | `properties.minimumTlsVersion: "TLS1_2"` | Explicitly set |
+| Shared key access disabled | 🟠 High | ✅ Applied | `properties.allowSharedKeyAccess: false` | Forces AAD/RBAC only |
+| No public blob access | 🟠 High | ✅ Applied | `properties.allowBlobPublicAccess: false` | No anonymous access |
+| Default to OAuth | 🟡 Medium | ✅ Applied | `properties.defaultToOAuthAuthentication: true` | Portal defaults to AAD |
+| Encryption at rest (SSE) | 🟡 Medium | 🔄 Platform Default | Not in template | Azure encrypts all storage at rest with platform-managed keys automatically |
+| Network rules | 🟡 Medium | ⚠️ Not applied | `networkAcls.defaultAction: "Allow"` | Open to all networks — consider restricting for prod |
+
+## App Service Plan (`asp-pyapi-dev-eastus`)
+
+| Check | Severity | Status | Evidence | Notes |
+|-------|----------|--------|----------|-------|
+| Linux OS | 🟡 Medium | ✅ Applied | `properties.reserved: true`, `kind: "linux"` | Required for Python runtime |
+
+## Application Insights (`appi-pyapi-dev-eastus`)
+
+| Check | Severity | Status | Evidence | Notes |
+|-------|----------|--------|----------|-------|
+| Workspace-based | 🟡 Medium | ✅ Applied | `properties.WorkspaceResourceId` references Log Analytics | Not classic (deprecated) mode |
+
+## RBAC Role Assignments
+
+| Check | Severity | Status | Evidence | Notes |
+|-------|----------|--------|----------|-------|
+| Storage Blob Data Owner | 🟠 High | ✅ Applied | Role `b7e6dc6d-...` assigned to Function App MI | Least-privilege for blob access |
+| Storage Account Contributor | 🟠 High | ✅ Applied | Role `17d1049b-...` assigned to Function App MI | Required for AzureWebJobsStorage identity-based access |
+
+## Recommendations (non-blocking)
+
+| # | Finding | Severity | Recommendation |
+|---|---------|----------|----------------|
+| 1 | Storage network open | 🟡 Medium | For prod: set `networkAcls.defaultAction: "Deny"` and add VNet integration |
+| 2 | No IP restrictions on Function App | 🟡 Medium | For prod: configure `ipSecurityRestrictions` |
+| 3 | No custom domain / WAF | ℹ️ Info | Consider Azure Front Door for production APIs |

--- a/.azure/deployments/deploy-20260512-082853/security-gate.json
+++ b/.azure/deployments/deploy-20260512-082853/security-gate.json
@@ -1,0 +1,9 @@
+{
+  "gate": "PASSED",
+  "iterations": 1,
+  "criticalPassed": true,
+  "highPassed": true,
+  "blockingFindings": [],
+  "overrideReason": null,
+  "timestamp": "2026-05-12T08:28:53Z"
+}

--- a/.azure/deployments/deploy-20260512-082853/template.json
+++ b/.azure/deployments/deploy-20260512-082853/template.json
@@ -1,0 +1,304 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "project": {
+      "type": "string",
+      "defaultValue": "pyapi",
+      "metadata": {
+        "description": "Project name used in resource naming"
+      }
+    },
+    "environment": {
+      "type": "string",
+      "defaultValue": "dev",
+      "allowedValues": ["dev", "staging", "prod"],
+      "metadata": {
+        "description": "Deployment environment"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "description": "Azure region for all resources"
+      }
+    },
+    "pythonVersion": {
+      "type": "string",
+      "defaultValue": "3.11",
+      "allowedValues": ["3.10", "3.11", "3.12"],
+      "metadata": {
+        "description": "Python runtime version"
+      }
+    }
+  },
+  "variables": {
+    "resourceGroupName": "[format('rg-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location'))]",
+    "storageAccountName": "[format('st{0}{1}{2}', parameters('project'), parameters('environment'), uniqueString(subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location')))))]",
+    "appServicePlanName": "[format('asp-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location'))]",
+    "functionAppName": "[format('func-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location'))]",
+    "appInsightsName": "[format('appi-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location'))]",
+    "logAnalyticsName": "[format('log-{0}-{1}-{2}', parameters('project'), parameters('environment'), parameters('location'))]",
+    "tags": {
+      "Environment": "[parameters('environment')]",
+      "Project": "[parameters('project')]",
+      "ManagedBy": "git-ape-agent",
+      "CreatedDate": "2026-05-12"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2024-03-01",
+      "name": "[variables('resourceGroupName')]",
+      "location": "[parameters('location')]",
+      "tags": "[variables('tags')]"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2024-03-01",
+      "name": "functionAppDeployment",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+      ],
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "appServicePlanName": {
+            "value": "[variables('appServicePlanName')]"
+          },
+          "functionAppName": {
+            "value": "[variables('functionAppName')]"
+          },
+          "appInsightsName": {
+            "value": "[variables('appInsightsName')]"
+          },
+          "logAnalyticsName": {
+            "value": "[variables('logAnalyticsName')]"
+          },
+          "pythonVersion": {
+            "value": "[parameters('pythonVersion')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "location": { "type": "string" },
+            "storageAccountName": { "type": "string" },
+            "appServicePlanName": { "type": "string" },
+            "functionAppName": { "type": "string" },
+            "appInsightsName": { "type": "string" },
+            "logAnalyticsName": { "type": "string" },
+            "pythonVersion": { "type": "string" },
+            "tags": { "type": "object" }
+          },
+          "variables": {
+            "storageBlobDataOwnerRoleId": "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+            "storageAccountContributorRoleId": "17d1049b-9a84-46fb-8f53-869881c3d3ab"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2023-09-01",
+              "name": "[parameters('logAnalyticsName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "sku": {
+                  "name": "PerGB2018"
+                },
+                "retentionInDays": 30
+              }
+            },
+            {
+              "type": "Microsoft.Insights/components",
+              "apiVersion": "2020-02-02",
+              "name": "[parameters('appInsightsName')]",
+              "location": "[parameters('location')]",
+              "kind": "web",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "Application_Type": "web",
+                "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsName'))]",
+                "publicNetworkAccessForIngestion": "Enabled",
+                "publicNetworkAccessForQuery": "Enabled"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-05-01",
+              "name": "[parameters('storageAccountName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "Standard_LRS"
+              },
+              "kind": "StorageV2",
+              "properties": {
+                "supportsHttpsTrafficOnly": true,
+                "minimumTlsVersion": "TLS1_2",
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": false,
+                "defaultToOAuthAuthentication": true,
+                "networkAcls": {
+                  "defaultAction": "Allow"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Web/serverfarms",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('appServicePlanName')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "kind": "linux",
+              "sku": {
+                "name": "Y1",
+                "tier": "Dynamic"
+              },
+              "properties": {
+                "reserved": true
+              }
+            },
+            {
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2024-04-01",
+              "name": "[parameters('functionAppName')]",
+              "location": "[parameters('location')]",
+              "kind": "functionapp,linux",
+              "tags": "[parameters('tags')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                "httpsOnly": true,
+                "siteConfig": {
+                  "linuxFxVersion": "[format('Python|{0}', parameters('pythonVersion'))]",
+                  "ftpsState": "Disabled",
+                  "minTlsVersion": "1.2",
+                  "http20Enabled": true,
+                  "appSettings": [
+                    {
+                      "name": "AzureWebJobsStorage__accountName",
+                      "value": "[parameters('storageAccountName')]"
+                    },
+                    {
+                      "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
+                      "value": ""
+                    },
+                    {
+                      "name": "FUNCTIONS_EXTENSION_VERSION",
+                      "value": "~4"
+                    },
+                    {
+                      "name": "FUNCTIONS_WORKER_RUNTIME",
+                      "value": "python"
+                    },
+                    {
+                      "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                      "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2020-02-02').ConnectionString]"
+                    },
+                    {
+                      "name": "WEBSITE_RUN_FROM_PACKAGE",
+                      "value": "1"
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), resourceId('Microsoft.Web/sites', parameters('functionAppName')), variables('storageBlobDataOwnerRoleId'))]",
+              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('storageAccountName'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataOwnerRoleId'))]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2024-04-01', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), resourceId('Microsoft.Web/sites', parameters('functionAppName')), variables('storageAccountContributorRoleId'))]",
+              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('storageAccountName'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageAccountContributorRoleId'))]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2024-04-01', 'Full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "functionAppId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
+            },
+            "functionAppDefaultHostName": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2024-04-01').defaultHostName]"
+            },
+            "functionAppPrincipalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2024-04-01', 'Full').identity.principalId]"
+            },
+            "appInsightsInstrumentationKey": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), '2020-02-02').InstrumentationKey]"
+            },
+            "storageAccountId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[variables('resourceGroupName')]"
+    },
+    "functionAppName": {
+      "type": "string",
+      "value": "[variables('functionAppName')]"
+    },
+    "functionAppHostName": {
+      "type": "string",
+      "value": "[reference('functionAppDeployment').outputs.functionAppDefaultHostName.value]"
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- add subscription-scope ARM deployment for a Python Function App\n- include security analysis + gate output\n- include architecture and metadata artifacts\n\n## Deployment\n- Trigger plan workflow on PR\n- Merge or use /deploy after approval to execute deployment\n\n## Resources\n- rg-pyapi-dev-eastus\n- func-pyapi-dev-eastus\n- stpyapidev<unique>\n- asp-pyapi-dev-eastus\n- appi-pyapi-dev-eastus\n- log-pyapi-dev-eastus\n