### PR TITLE
chore: recover version drift to v0.0.3 and seed CHANGELOG

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Git-Ape — Intelligent Azure deployment agent and skill suite for GitHub Copilot. Onboard any repository with guided ARM template generation, security analysis, cost estimation, drift detection, and automated CI/CD pipelines.",
-    "version": "0.0.1"
+    "version": "0.0.3"
   },
   "plugins": [
     {
       "name": "git-ape",
       "description": "Intelligent Azure deployment agent system for GitHub Copilot. Provides guided, safe, and validated Azure resource deployments using ARM templates, with built-in security analysis, cost estimation, drift detection, and CI/CD pipeline integration.",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "source": "."
     },
     {
@@ -39,6 +39,6 @@
         "repo": "suuus/ape-context",
         "path": ".github/plugins/ape-context"
       }
-        }
+    }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project are documented here.
+This project follows [Semantic Versioning](https://semver.org/).
+
+> Entries for `0.0.2` and `0.0.3` were reconstructed retroactively as part of
+> recovering version-bump drift on `main`; future entries are generated
+> automatically by the release workflow.
+
+## [0.0.3] - 2026-05-13
+
+### Documentation
+
+- **extension:** fill VS Code Marketplace listing and surface install paths (`d6c6a8f`)
+- Make VS Code install badges clickable via HTTPS redirects (`58905b5`)
+- **extension:** add blank line between list and heading to satisfy markdownlint (`d6a6e3f`)
+
+### Dependencies
+
+- **website:** bump mermaid from 11.14.0 to 11.15.0 (`434796f`)
+
+## [0.0.2] - 2026-05-11
+
+### Features
+
+- **extension:** add VS Code extension scaffolding and CI/CD workflows (`b6bcc13`)
+- **extension:** set publisher to Git-APE and auto-publish to VS Code Marketplace (`845b6c2`)
+- **release:** publish to VS Code Marketplace using odd-minor channel convention (`6b5cebf`)
+- **plugin:** add `ape-context` plugin for enhanced context management (`ac2c892`)
+- **devcontainer:** customize dev environment and add VS Code tasks (`f5fce29`)
+- **devcontainer:** split into website and agent-engineering configs (`2131f9f`)
+- **devcontainer:** add waza CLI and chat-customizations-evaluations to agent container (`d4972db`)
+- **devcontainer:** ensure sandbox dependencies are installed before IaC tools (`d428922`)
+- Add `CONTRIBUTING.md` and structural PR validation CI (`0dec1ad`)
+- Add agentic workflows for issue-triage and daily repo status (`14bda1c`, `2de05d1`)
+
+### Bug Fixes
+
+- **extension:** correct chat contribution schema and bump engines/Node (`71c8c9d`)
+- **extension:** set publisher to Git-ApeTeam (`2302f73`)
+- **release:** remove stray `gh release upload` from marketplace publish step (`11c8fe4`)
+- **workflows:** disable lockdown on issue-triage-agent (`8732a46`)
+- **workflows:** silence SC2015 in gh-aw lock files and fix README fences (`499d25c`)
+- **workflows:** recompile gh-aw lock files to v0.72.1 for valid awf release (`19cab81`)
+- **devcontainer:** use sudo for waza installation to ensure proper binary placement (`96ebebe`)
+- **devcontainer:** correct image tag for Git-Ape Website (`5c84ec5`)
+
+### Documentation
+
+- Reframe pitch as workload-agnostic and document workflow activation (`5080705`)
+
+### Performance
+
+- **devcontainer:** tighten install steps in both containers (`e2a1eab`)
+
+### CI/CD
+
+- **deps:** add Dependabot, bump Node to 24 LTS (`3d23ee0`)
+
+### Chores
+
+- **devcontainer:** drop Node feature from agent container (`451fde8`)
+- Remove downloaded actionlint binary (`58df8de`)
+
+### Dependencies
+
+- **website:** bump the react group across 1 directory with 2 updates (`3ddf958`)
+- **website:** bump the docusaurus group (`caa7d32`)
+- **website:** bump `@babel/plugin-transform-modules-systemjs` (`ef6a125`)
+- **website:** bump `fast-uri` from 3.1.0 to 3.1.2 (`6997bdb`)
+- **actions:** bump the github-actions group with 7 updates (`e8aa1a3`)
+
+## [0.0.1] - 2026-05-05
+
+Initial tagged release.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-ape",
   "description": "Intelligent agent system for deploying any Azure workload through GitHub Copilot. Provides guided, safe, and validated deployments using ARM templates, with built-in security analysis, cost estimation, and CI/CD pipeline integration.",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/Azure/git-ape"


### PR DESCRIPTION
## Why

The release workflow's `Commit version bump` step was gated to `workflow_dispatch` only ([git-ape-release.yml#L100](https://github.com/Azure/git-ape/blob/main/.github/workflows/git-ape-release.yml#L100)), so the tag-push releases for **v0.0.2** and **v0.0.3** never wrote the bumped `plugin.json` / `.github/plugin/marketplace.json` back to `main`. The post-release CHANGELOG step likely opened a `changelog/<tag>` PR each time that was never merged.

As a result `main` has been frozen at `0.0.1` with no `CHANGELOG.md` since the first release, even though [v0.0.3](https://github.com/Azure/git-ape/releases/tag/v0.0.3) shipped on 2026-05-13.

## What

- Bump `plugin.json` → `0.0.3`
- Bump `.github/plugin/marketplace.json`:
  - `metadata.version` → `0.0.3`
  - `plugins[name=git-ape].version` → `0.0.3`
  - `plugins[name=ape-context]` left at its own `1.0.0`
- Add `CHANGELOG.md` with reconstructed entries for `v0.0.2` and `v0.0.3` (and a stub for `v0.0.1`)
- `website/package.json` is intentionally untouched (docs versioning is decoupled)

## Workflow fix

The underlying bug in `.github/workflows/git-ape-release.yml` (it now re-applies the bump against the fresh `main` tree inside the same step that writes the CHANGELOG, so tag-push releases land both files together) is on a separate branch and will follow as its own PR.

## Validation

```
plugin.json:        0.0.3
marketplace meta:   0.0.3
marketplace entry:  git-ape=0.0.3, ape-context=1.0.0
```

The plugin version check workflow (`.github/workflows/git-ape-plugin-version-check.yml`) should pass on this PR.