### PR TITLE
fix(release): always publish stable to VS Code Marketplace

### DIFF
--- a/.github/workflows/git-ape-release.yml
+++ b/.github/workflows/git-ape-release.yml
@@ -308,28 +308,19 @@ jobs:
           fi
 
           # VS Code Marketplace rejects semver pre-release suffixes
-          # (e.g. 0.1.0-rc.1). The official channel model uses odd minors
-          # for the Pre-Release channel and even minors for Release.
-          # See: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+          # (e.g. 0.1.0-rc.1). We publish every release as a stable
+          # marketplace release regardless of minor parity — the odd/even
+          # minor convention is opt-in and would require packaging the VSIX
+          # with --pre-release to match, which we don't do here.
           if [[ "$VERSION" == *-* ]]; then
             echo "Version $VERSION carries a semver pre-release suffix, which the"
             echo "VS Code Marketplace does not accept. Skipping marketplace publish."
             exit 0
           fi
 
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          if (( MINOR % 2 == 1 )); then
-            FLAG="--pre-release"
-            CHANNEL="Pre-Release"
-          else
-            FLAG=""
-            CHANNEL="Release"
-          fi
-
           VSIX_FILE=$(ls ./*.vsix)
-          echo "Publishing $VSIX_FILE to VS Code Marketplace ($CHANNEL channel)"
-          # shellcheck disable=SC2086
-          vsce publish --packagePath "$VSIX_FILE" --no-dependencies $FLAG
+          echo "Publishing $VSIX_FILE to VS Code Marketplace (Release channel)"
+          vsce publish --packagePath "$VSIX_FILE" --no-dependencies
 
       - name: Update CHANGELOG.md on main
         if: steps.ver.outputs.prerelease == 'false'


### PR DESCRIPTION
## Why

Run https://github.com/Azure/git-ape/actions/runs/26485522294 failed at the `Publish to VS Code Marketplace` step with:

> Cannot use '--pre-release' flag with a package that was not packaged as pre-release. Please package it using the '--pre-release' flag and publish again.

For `v0.1.0`, the workflow computed `MINOR=1` → odd → `vsce publish --pre-release`, but the VSIX is always packaged **without** `--pre-release`, so `vsce` rejected it.

The odd-minor / even-minor channel scheme is an **opt-in** convention used by some Microsoft extensions (Python, etc.), **not** a Marketplace requirement.

## What

- Removed the odd/even minor branching in the marketplace publish step.
- Always publish as a stable Marketplace release.
- Kept the existing guard: semver pre-release suffixes (e.g. `0.1.0-rc.1`) continue to skip marketplace publish entirely.

## Follow-up

`v0.1.0` cannot be re-published with the same version. Cut a new tag (e.g. `v0.1.1`) after merge to verify the publish path.