### PR TITLE
chore(git-ape): switch progress bar from ASCII to Unicode blocks

### DIFF
--- a/.github/agents/git-ape.agent.md
+++ b/.github/agents/git-ape.agent.md
@@ -18,16 +18,18 @@ You are **Git-Ape**, responsible for managing end-to-end Azure resource deployme
 
 ## Output Styling (All Modes)
 
-Make deployment-related output visually structured and consistent. Use clear stage headers, compact status blocks, and ASCII progress bars where helpful. Keep it readable in plain text and Markdown.
+Make deployment-related output visually structured and consistent. Use clear stage headers, compact status blocks, and Unicode block progress bars where helpful. Keep it readable in plain text and Markdown.
 
 ### Shared Presentation Style
 
 All subagents must follow the styles below for deployment-related output.
 
-**Progress Bar Pattern (ASCII-only):**
+**Progress Bar Pattern (Unicode blocks):**
 ```
-[####------] 40%  Stage 2/4: Template Generation
+[████░░░░░░] 40%  Stage 2/4: Template Generation
 ```
+
+Use `█` (U+2588 FULL BLOCK) for filled cells and `░` (U+2591 LIGHT SHADE) for empty cells. Keep the bar 10 cells wide so each cell represents 10%.
 
 **Status Line Pattern:**
 ```
@@ -45,19 +47,19 @@ Stage 3/4: Deployment Execution
 ### Sample Deployment Output
 
 ```
-[##--------] 20%  Stage 1/4: Requirements Gathering
+[██░░░░░░░░] 20%  Stage 1/4: Requirements Gathering
 Status: Running | Elapsed: 00:45 | Next: Template Generation
 
-[####------] 40%  Stage 2/4: Template Generation
+[████░░░░░░] 40%  Stage 2/4: Template Generation
 Status: Ready for confirmation | Elapsed: 02:10 | Next: Deployment Execution
 
-[######----] 60%  Stage 3/4: Deployment Execution
+[██████░░░░] 60%  Stage 3/4: Deployment Execution
 Status: Running | Elapsed: 04:30 | Next check: 00:30
 - ✓ resourceGroup (Succeeded)
 - ⧗ storageAccount (Running)
 - ⧗ functionApp (Running)
 
-[##########] 100%  Stage 4/4: Post-Deployment Validation
+[██████████] 100%  Stage 4/4: Post-Deployment Validation
 Status: Succeeded | Duration: 06:12
 ```
 

--- a/website/docs/agents/git-ape.md
+++ b/website/docs/agents/git-ape.md
@@ -58,16 +58,18 @@ You are **Git-Ape**, responsible for managing end-to-end Azure resource deployme
 
 ## Output Styling (All Modes)
 
-Make deployment-related output visually structured and consistent. Use clear stage headers, compact status blocks, and ASCII progress bars where helpful. Keep it readable in plain text and Markdown.
+Make deployment-related output visually structured and consistent. Use clear stage headers, compact status blocks, and Unicode block progress bars where helpful. Keep it readable in plain text and Markdown.
 
 ### Shared Presentation Style
 
 All subagents must follow the styles below for deployment-related output.
 
-**Progress Bar Pattern (ASCII-only):**
+**Progress Bar Pattern (Unicode blocks):**
 ```
-[####------] 40%  Stage 2/4: Template Generation
+[████░░░░░░] 40%  Stage 2/4: Template Generation
 ```
+
+Use `█` (U+2588 FULL BLOCK) for filled cells and `░` (U+2591 LIGHT SHADE) for empty cells. Keep the bar 10 cells wide so each cell represents 10%.
 
 **Status Line Pattern:**
 ```
@@ -85,19 +87,19 @@ Stage 3/4: Deployment Execution
 ### Sample Deployment Output
 
 ```
-[##--------] 20%  Stage 1/4: Requirements Gathering
+[██░░░░░░░░] 20%  Stage 1/4: Requirements Gathering
 Status: Running | Elapsed: 00:45 | Next: Template Generation
 
-[####------] 40%  Stage 2/4: Template Generation
+[████░░░░░░] 40%  Stage 2/4: Template Generation
 Status: Ready for confirmation | Elapsed: 02:10 | Next: Deployment Execution
 
-[######----] 60%  Stage 3/4: Deployment Execution
+[██████░░░░] 60%  Stage 3/4: Deployment Execution
 Status: Running | Elapsed: 04:30 | Next check: 00:30
 - ✓ resourceGroup (Succeeded)
 - ⧗ storageAccount (Running)
 - ⧗ functionApp (Running)
 
-[##########] 100%  Stage 4/4: Post-Deployment Validation
+[██████████] 100%  Stage 4/4: Post-Deployment Validation
 Status: Succeeded | Duration: 06:12
 ```
 


### PR DESCRIPTION
## What

Replace the ASCII progress bar in the Git-Ape agent output style with Unicode block characters:

- Filled cells: `█` (U+2588 FULL BLOCK) instead of `#`
- Empty cells: `░` (U+2591 LIGHT SHADE) instead of `-`

Bar stays 10 cells wide (each cell = 10%).

**Before:**
```
[####------] 40%  Stage 2/4: Template Generation
```

**After:**
```
[████░░░░░░] 40%  Stage 2/4: Template Generation
```

## Why

Unicode block bars render as a continuous shaded bar in both Markdown renderers and modern terminals, which reads more like a progress bar and less like a literal grid of characters. All Git-Ape output already uses Unicode glyphs elsewhere (`✓`, `⧗`), so this is consistent.

## Files

- `.github/agents/git-ape.agent.md` — source change
- `website/docs/agents/git-ape.md` — regenerated mirror (auto-generated by `scripts/generate-docs.js`)