### PR TITLE
chore(daily-status): move schedule to 08:00 SGT (00:00 UTC)

### DIFF
--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -54,7 +54,7 @@
 name: "Daily Repo Status"
 "on":
   schedule:
-  - cron: "25 10 * * *"
+  - cron: "0 0 * * *"
     # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:

--- a/.github/workflows/daily-repo-status.md
+++ b/.github/workflows/daily-repo-status.md
@@ -6,7 +6,9 @@ description: |
   and project recommendations.
 
 on:
-  schedule: daily
+  # 08:00 SGT (UTC+8) every day = 00:00 UTC
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Switches the `daily-repo-status` workflow from the gh-aw `schedule: daily` fuzzy default (which had been compiling to `25 10 * * *` UTC ≈ 18:25 SGT) to a fixed `0 0 * * *` UTC, i.e. **08:00 SGT** every day.

### Why

- The fuzzy daily run had been missing days recently (last successful schedule: May 25; May 26 and May 27 skipped — typical GitHub-Actions scheduled-workflow drop behaviour).
- Pinning to an explicit UTC hour makes monitoring easier and aligns delivery with the start of the SGT workday.

### Files

- `.github/workflows/daily-repo-status.md` — source: switched `schedule: daily` → explicit cron.
- `.github/workflows/daily-repo-status.lock.yml` — mirrors the cron change (single-line patch; full `gh aw compile` was skipped to avoid sweeping in unrelated tool-version drift).