### PR TITLE
fix(prereq-check): parse az version via JSON on PowerShell

### DIFF
--- a/.github/skills/prereq-check/scripts/check-tools.ps1
+++ b/.github/skills/prereq-check/scripts/check-tools.ps1
@@ -57,7 +57,11 @@ $arch = if ($env:PROCESSOR_ARCHITECTURE) {
 "Platform: $os / $arch"
 
 Check-Tool 'az' {
-    az version --query '"azure-cli"' -o tsv
+    # Avoid `--query '"azure-cli"'` — PowerShell's native-command parser strips
+    # the inner double-quotes, leaving JMESPath with an unquoted hyphenated
+    # identifier (`azure-cli`) that fails to parse. Parse JSON instead.
+    $v = az version -o json 2>$null | ConvertFrom-Json
+    if ($v) { $v.'azure-cli' } else { '' }
 }
 Check-Tool 'gh' {
     $line = (gh --version 2>$null | Select-Object -First 1)


### PR DESCRIPTION
Closes #130.

## Problem

On Windows / PowerShell, `prereq-check` reports `az` as `OUTDATED unknown` even when a current Azure CLI is installed, blocking Git-Ape onboarding.

PowerShell's native-command argument parser strips the inner double-quotes from:

```powershell
az version --query '"azure-cli"' -o tsv
```

The CLI ends up receiving the JMESPath query `azure-cli` (no quotes), which is an invalid identifier because of the hyphen — JMESPath fails to parse, `stdout` is empty, and the script falls back to the literal string `unknown`.

The POSIX sibling `check-tools.sh` is unaffected because POSIX shells preserve inner quotes.

## Fix

Replace the JMESPath query with native PowerShell JSON parsing:

```powershell
$v = az version -o json 2>$null | ConvertFrom-Json
if ($v) { $v.'azure-cli' } else { '' }
```

This sidesteps the quoting issue entirely. The TSV contract emitted by the script is unchanged, so `prereq-check`'s SKILL.md consumer keeps working without modification.

## Verification

Local run on macOS (pwsh 7.x):

```text
Platform: Darwin / arm64
az      OK      2.86.0  2.50
gh      OK      2.92.0  2.0
jq      OK      1.8     1.6
git     OK      2.54.0  0
```

`node scripts/validate-structure.js` → 0 errors, no new warnings.
