### PR TITLE
Add Git-Ape prompt file

### DIFF
--- a/.github/prompts/git-ape.prompt.md
+++ b/.github/prompts/git-ape.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: Git-Ape
+---


### PR DESCRIPTION
This pull request makes a minor update to the `.github/prompts/git-ape.prompt.md` file by adding front matter specifying the agent as `Git-Ape`. This helps clarify which agent the prompt is intended for.