### PR TITLE
chore(workflows): recompile daily-repo-status lockfile against current source

### DIFF
--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"894339bb13dd70330e962756b5d6c9f0b1e2a45fa72eb57fed9eda15479a0af4","compiler_version":"v0.76.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e28027ab984b676c4452279cea43d3b83bc209351eb48ea197ca509a66e3cc85","compiler_version":"v0.76.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"46d564922b082d0db93244972e8005ea6904ee5f","version":"v0.76.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.55"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.55"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.19"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,7 +55,6 @@ name: "Daily Repo Status"
 on:
   schedule:
   - cron: "0 0 * * *"
-    # Friendly format: daily (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -195,20 +194,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_310a08ed815a7265_EOF'
+          cat << 'GH_AW_PROMPT_9dd56e6c580fbeb5_EOF'
           <system>
-          GH_AW_PROMPT_310a08ed815a7265_EOF
+          GH_AW_PROMPT_9dd56e6c580fbeb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_310a08ed815a7265_EOF'
+          cat << 'GH_AW_PROMPT_9dd56e6c580fbeb5_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_310a08ed815a7265_EOF
+          GH_AW_PROMPT_9dd56e6c580fbeb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_310a08ed815a7265_EOF'
+          cat << 'GH_AW_PROMPT_9dd56e6c580fbeb5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -237,12 +236,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_310a08ed815a7265_EOF
+          GH_AW_PROMPT_9dd56e6c580fbeb5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_310a08ed815a7265_EOF'
+          cat << 'GH_AW_PROMPT_9dd56e6c580fbeb5_EOF'
           </system>
           {{#runtime-import .github/workflows/daily-repo-status.md}}
-          GH_AW_PROMPT_310a08ed815a7265_EOF
+          GH_AW_PROMPT_9dd56e6c580fbeb5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -450,9 +449,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1318fba0649d9410_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_631dae4d655044a9_EOF'
           {"create_issue":{"close_older_issues":true,"labels":["report","daily-status"],"max":1,"title_prefix":"[repo-status] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_1318fba0649d9410_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_631dae4d655044a9_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -658,7 +657,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_748eb5049957e6dc_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ab444830d49295a4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -702,7 +701,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_748eb5049957e6dc_EOF
+          GH_AW_MCP_CONFIG_ab444830d49295a4_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true


### PR DESCRIPTION
## Why

PR #136 regenerated the gh-aw lock files **before** PR #127 (move daily-status to 08:00 SGT) landed on `main`. After both merges, the committed `daily-repo-status.lock.yml` carries `frontmatter_hash` for the pre-SGT source (`schedule: daily`), but the source `.md` on `main` now uses the cron form. Every dispatched/scheduled run fails the integrity check:

```
ERR_CONFIG: Lock file '.github/workflows/daily-repo-status.lock.yml' is outdated!
The workflow file '.github/workflows/daily-repo-status.md' frontmatter has changed.
Run 'gh aw compile' to regenerate the lock file.
```

Observed in [run 26559296328](https://github.com/Azure/git-ape/actions/runs/26559296328).

## What

Recompiled with `gh aw v0.76.1` against the current source. Only `daily-repo-status.lock.yml` drifted; `issue-triage-agent.lock.yml` matches its source.

Diff is a hash refresh + drop of a stale inline comment + churn on generated heredoc tokens (`GH_AW_PROMPT_*`, `GH_AW_SAFE_OUTPUTS_CONFIG_*`, `GH_AW_MCP_CONFIG_*`).