### PR TITLE
chore(evals): pin LLM-as-judge to claude-opus-4.7 to eliminate self-grading bias

### DIFF
--- a/.github/prompts/agent-onboard.prompt.md
+++ b/.github/prompts/agent-onboard.prompt.md
@@ -457,6 +457,9 @@ waza run ".github/evals/agents/${agent}/eval.yaml" \
 same reason as `/agent-promote`: judge sits outside every runner
 roster, so smoke verdicts cannot leak self-grading bias even if the
 operator changes `smokeModel`. `smokeModel` only swaps the runner.
+The one exception: if the operator sets `smokeModel` to
+`claude-opus-4.7` (the same value as `--judge-model`), the smoke run
+becomes self-graded — avoid that pairing.
 
 Parse the result JSON and report:
 

--- a/.github/prompts/agent-onboard.prompt.md
+++ b/.github/prompts/agent-onboard.prompt.md
@@ -447,11 +447,16 @@ graders wire up correctly — not a quality assessment.
 mkdir -p /tmp/waza-runs
 waza run ".github/evals/agents/${agent}/eval.yaml" \
   --model "${input:smokeModel:claude-sonnet-4.6}" \
-  --judge-model "claude-sonnet-4.6" \
+  --judge-model "claude-opus-4.7" \
   --no-cache \
   --output "/tmp/waza-runs/${agent}-onboard-smoke.json" \
   2>&1 | tail -10
 ```
+
+`--judge-model claude-opus-4.7` is fixed (NOT a parameter) for the
+same reason as `/agent-promote`: judge sits outside every runner
+roster, so smoke verdicts cannot leak self-grading bias even if the
+operator changes `smokeModel`. `smokeModel` only swaps the runner.
 
 Parse the result JSON and report:
 

--- a/.github/prompts/agent-promote.prompt.md
+++ b/.github/prompts/agent-promote.prompt.md
@@ -105,15 +105,26 @@ for model in ${models[@]}; do
   echo "▶ Eval: ${model}"
   waza run ".github/evals/agents/${agent}/eval.yaml" \
     --model "${model}" \
-    --judge-model "claude-sonnet-4.6" \
+    --judge-model "claude-opus-4.7" \
     --no-cache \
     --output "/tmp/waza-promote/${agent}-${model}.json" \
     2>&1 | tail -3
 done
 ```
 
-Use `--judge-model claude-sonnet-4.6` for stable cross-model quality
-scoring. Run sequentially — quota consumption stays predictable.
+`--judge-model claude-opus-4.7` pins the LLM-as-judge to a model that
+is NOT in any runner roster (pilot or expanded). Two reasons:
+
+1. **No self-grading bias.** When the same model is both runner and
+   judge, that leg's prompt-grader verdicts conflate model capability
+   with judge agreement. Pinning the judge outside the roster gives
+   every leg an independent grader.
+2. **Judge capability ≥ every runner.** `claude-opus-4.7` strictly
+   dominates the current pilot/expanded runner mix (sonnet-4.6,
+   gpt-5.4, gpt-5.3-codex, opus-4.6) on reasoning benchmarks, so it
+   can score the strongest runner outputs without ceiling effects.
+
+Run sequentially — quota consumption stays predictable.
 
 ### Step 4 — Token budget check
 

--- a/.github/prompts/agent-promote.prompt.md
+++ b/.github/prompts/agent-promote.prompt.md
@@ -119,10 +119,10 @@ is NOT in any runner roster (pilot or expanded). Two reasons:
    judge, that leg's prompt-grader verdicts conflate model capability
    with judge agreement. Pinning the judge outside the roster gives
    every leg an independent grader.
-2. **Judge capability ≥ every runner.** `claude-opus-4.7` strictly
-   dominates the current pilot/expanded runner mix (sonnet-4.6,
-   gpt-5.4, gpt-5.3-codex, opus-4.6) on reasoning benchmarks, so it
-   can score the strongest runner outputs without ceiling effects.
+2. **Judge capability ≥ every runner.** `claude-opus-4.7` is chosen as
+   a higher-capability judge than the current pilot/expanded runner mix
+   (sonnet-4.6, gpt-5.4, gpt-5-codex, opus-4.6) to reduce ceiling
+   effects when scoring the strongest runner outputs.
 
 Run sequentially — quota consumption stays predictable.
 

--- a/.github/prompts/skill-onboard.prompt.md
+++ b/.github/prompts/skill-onboard.prompt.md
@@ -365,6 +365,9 @@ waza run ".github/evals/${skill}/eval.yaml" \
 same reason as `/skill-promote`: judge sits outside every runner
 roster, so smoke verdicts cannot leak self-grading bias even if the
 operator changes `smokeModel`. `smokeModel` only swaps the runner.
+The one exception: if the operator sets `smokeModel` to
+`claude-opus-4.7` (the same value as `--judge-model`), the smoke run
+becomes self-graded — avoid that pairing.
 
 Parse the result JSON and report:
 

--- a/.github/prompts/skill-onboard.prompt.md
+++ b/.github/prompts/skill-onboard.prompt.md
@@ -355,11 +355,16 @@ graders wire up correctly — not a quality assessment.
 mkdir -p /tmp/waza-runs
 waza run ".github/evals/${skill}/eval.yaml" \
   --model "${input:smokeModel:claude-sonnet-4.6}" \
-  --judge-model "claude-sonnet-4.6" \
+  --judge-model "claude-opus-4.7" \
   --no-cache \
   --output "/tmp/waza-runs/${skill}-smoke.json" \
   2>&1 | tail -10
 ```
+
+`--judge-model claude-opus-4.7` is fixed (NOT a parameter) for the
+same reason as `/skill-promote`: judge sits outside every runner
+roster, so smoke verdicts cannot leak self-grading bias even if the
+operator changes `smokeModel`. `smokeModel` only swaps the runner.
 
 Parse the result JSON and report:
 

--- a/.github/prompts/skill-promote.prompt.md
+++ b/.github/prompts/skill-promote.prompt.md
@@ -69,15 +69,26 @@ for model in ${models[@]}; do
   echo "▶ Eval: ${model}"
   waza run ".github/evals/${skill}/eval.yaml" \
     --model "${model}" \
-    --judge-model "claude-sonnet-4.6" \
+    --judge-model "claude-opus-4.7" \
     --no-cache \
     --output "/tmp/waza-promote/${skill}-${model}.json" \
     2>&1 | tail -3
 done
 ```
 
-Use `--judge-model claude-sonnet-4.6` for stable cross-model quality
-scoring. Run sequentially — quota consumption stays predictable.
+`--judge-model claude-opus-4.7` pins the LLM-as-judge to a model that
+is NOT in any runner roster (pilot or expanded). Two reasons:
+
+1. **No self-grading bias.** When the same model is both runner and
+   judge, that leg's prompt-grader verdicts conflate model capability
+   with judge agreement. Pinning the judge outside the roster gives
+   every leg an independent grader.
+2. **Judge capability ≥ every runner.** `claude-opus-4.7` strictly
+   dominates the current pilot/expanded runner mix (sonnet-4.6,
+   gpt-5.4, gpt-5.3-codex, opus-4.6) on reasoning benchmarks, so it
+   can score the strongest runner outputs without ceiling effects.
+
+Run sequentially — quota consumption stays predictable.
 
 ### Step 3 — Token budget check
 

--- a/.github/prompts/skill-promote.prompt.md
+++ b/.github/prompts/skill-promote.prompt.md
@@ -83,10 +83,10 @@ is NOT in any runner roster (pilot or expanded). Two reasons:
    judge, that leg's prompt-grader verdicts conflate model capability
    with judge agreement. Pinning the judge outside the roster gives
    every leg an independent grader.
-2. **Judge capability ≥ every runner.** `claude-opus-4.7` strictly
-   dominates the current pilot/expanded runner mix (sonnet-4.6,
-   gpt-5.4, gpt-5.3-codex, opus-4.6) on reasoning benchmarks, so it
-   can score the strongest runner outputs without ceiling effects.
+2. **Judge capability ≥ every runner.** `claude-opus-4.7` is chosen as
+   a higher-capability judge than the current pilot/expanded runner mix
+   (sonnet-4.6, gpt-5.4, gpt-5-codex, opus-4.6) to reduce ceiling
+   effects when scoring the strongest runner outputs.
 
 Run sequentially — quota consumption stays predictable.
 

--- a/.github/workflows/waza-agent-evals.yml
+++ b/.github/workflows/waza-agent-evals.yml
@@ -487,9 +487,17 @@ jobs:
           # fallback path (no JSON → use rawMd) will surface that notice
           # instead of polluting the score table.
           #
-          # --judge-model is decoupled from the executor model so quality
-          # scores are always judged by claude-sonnet-4.6 even if we ever
-          # add per-agent model overrides.
+          # --judge-model is decoupled from the executor model and pinned
+          # to claude-opus-4.7 for TWO reasons:
+          #   1. No self-grading bias — opus-4.7 is NOT in any runner
+          #      roster (this workflow currently fixes the runner to
+          #      sonnet-4.6, but the rule holds: judge is always outside
+          #      whatever set of models we ever fan runners across).
+          #   2. Judge capability ≥ runner — opus-4.7 dominates sonnet-4.6
+          #      on reasoning benchmarks, so quality scores have headroom
+          #      and aren't capped by a same-tier judge.
+          # If we ever add per-agent model overrides AND opus-4.7 lands in
+          # a runner roster, re-pin the judge to a model still outside it.
           max_attempts=3
           attempt=0
           rc=0
@@ -499,7 +507,7 @@ jobs:
             rc=0
             waza run "${spec}" \
               --model "claude-sonnet-4.6" \
-              --judge-model "claude-sonnet-4.6" \
+              --judge-model "claude-opus-4.7" \
               --suggest \
               --recommend \
               --format "github-comment" \

--- a/.github/workflows/waza-agent-evals.yml
+++ b/.github/workflows/waza-agent-evals.yml
@@ -493,9 +493,9 @@ jobs:
           #      roster (this workflow currently fixes the runner to
           #      sonnet-4.6, but the rule holds: judge is always outside
           #      whatever set of models we ever fan runners across).
-          #   2. Judge capability ≥ runner — opus-4.7 dominates sonnet-4.6
-          #      on reasoning benchmarks, so quality scores have headroom
-          #      and aren't capped by a same-tier judge.
+          #   2. Judge capability ≥ runner — opus-4.7 is chosen as a
+          #      higher-capability judge than sonnet-4.6 so quality scores
+          #      have headroom and aren't capped by a same-tier judge.
           # If we ever add per-agent model overrides AND opus-4.7 lands in
           # a runner roster, re-pin the judge to a model still outside it.
           max_attempts=3

--- a/.github/workflows/waza-evals.yml
+++ b/.github/workflows/waza-evals.yml
@@ -485,12 +485,12 @@ jobs:
           # --judge-model decouples the LLM-as-judge from the executor model
           # and pins it to claude-opus-4.7 for TWO reasons:
           #   1. No self-grading bias — opus-4.7 is NOT in any matrix tier
-          #      (pilot: sonnet-4.6, gpt-5.4, gpt-5.3-codex, opus-4.6;
-          #      expanded: sonnet-4.6, gpt-5.3-codex), so no runner leg is
+          #      (pilot: sonnet-4.6, gpt-5.4, gpt-5-codex, opus-4.6;
+          #      expanded: sonnet-4.6, gpt-5-codex), so no runner leg is
           #      ever judged by its own model.
-          #   2. Judge capability ≥ every runner — opus-4.7 strictly
-          #      dominates the runner mix on reasoning benchmarks, so it
-          #      can score the strongest runners without ceiling effects.
+          #   2. Judge capability ≥ every runner — opus-4.7 is chosen as a
+          #      higher-capability judge than the runner mix to reduce
+          #      ceiling effects when scoring the strongest runners.
           # If a future tier ever adds opus-4.7 as a runner, the judge must
           # be re-pinned to a model that is still outside the new roster.
           #

--- a/.github/workflows/waza-evals.yml
+++ b/.github/workflows/waza-evals.yml
@@ -848,7 +848,7 @@ jobs:
               '',
               '> **Legend:** Models flagged `baseline: true` in `.github/evals/manifest.yaml` (currently: `' +
                 (Array.from(baselineModels).join('`, `') || 'none') +
-                '`) run with `--baseline` (A/B mode) to cap quota. All other models run standard. Judge model is fixed at `claude-sonnet-4.6` across all legs.',
+                '`) run with `--baseline` (A/B mode) to cap quota. All other models run standard. Judge model is fixed at `claude-opus-4.7` across all legs.',
               '',
             ].filter((line) => line !== null).join('\n');
 

--- a/.github/workflows/waza-evals.yml
+++ b/.github/workflows/waza-evals.yml
@@ -481,8 +481,19 @@ jobs:
           # task results, "Running benchmark:") streams to the runner log.
           # --model overrides the spec's config.model so we can fan out the
           # same eval suite across multiple models.
+          #
           # --judge-model decouples the LLM-as-judge from the executor model
-          # so quality scores are always judged by claude-sonnet-4.6.
+          # and pins it to claude-opus-4.7 for TWO reasons:
+          #   1. No self-grading bias — opus-4.7 is NOT in any matrix tier
+          #      (pilot: sonnet-4.6, gpt-5.4, gpt-5.3-codex, opus-4.6;
+          #      expanded: sonnet-4.6, gpt-5.3-codex), so no runner leg is
+          #      ever judged by its own model.
+          #   2. Judge capability ≥ every runner — opus-4.7 strictly
+          #      dominates the runner mix on reasoning benchmarks, so it
+          #      can score the strongest runners without ceiling effects.
+          # If a future tier ever adds opus-4.7 as a runner, the judge must
+          # be re-pinned to a model that is still outside the new roster.
+          #
           # --suggest --recommend appends outcome-tied recommendations.
           max_attempts=3
           attempt=0
@@ -494,7 +505,7 @@ jobs:
             # shellcheck disable=SC2086
             waza run "${spec}" \
               --model "${{ matrix.model }}" \
-              --judge-model "claude-sonnet-4.6" \
+              --judge-model "claude-opus-4.7" \
               --suggest \
               --recommend \
               ${extra_flags} \

--- a/website/docs/workflows/waza-agent-evals.md
+++ b/website/docs/workflows/waza-agent-evals.md
@@ -565,9 +565,17 @@ jobs:
           # fallback path (no JSON → use rawMd) will surface that notice
           # instead of polluting the score table.
           #
-          # --judge-model is decoupled from the executor model so quality
-          # scores are always judged by claude-opus-4.7 even if we ever
-          # add per-agent model overrides.
+          # --judge-model is decoupled from the executor model and pinned
+          # to claude-opus-4.7 for TWO reasons:
+          #   1. No self-grading bias — opus-4.7 is NOT in any runner
+          #      roster (this workflow currently fixes the runner to
+          #      sonnet-4.6, but the rule holds: judge is always outside
+          #      whatever set of models we ever fan runners across).
+          #   2. Judge capability ≥ runner — opus-4.7 is chosen as a
+          #      higher-capability judge than sonnet-4.6 so quality scores
+          #      have headroom and aren't capped by a same-tier judge.
+          # If we ever add per-agent model overrides AND opus-4.7 lands in
+          # a runner roster, re-pin the judge to a model still outside it.
           max_attempts=3
           attempt=0
           rc=0

--- a/website/docs/workflows/waza-agent-evals.md
+++ b/website/docs/workflows/waza-agent-evals.md
@@ -566,7 +566,7 @@ jobs:
           # instead of polluting the score table.
           #
           # --judge-model is decoupled from the executor model so quality
-          # scores are always judged by claude-sonnet-4.6 even if we ever
+          # scores are always judged by claude-opus-4.7 even if we ever
           # add per-agent model overrides.
           max_attempts=3
           attempt=0
@@ -577,7 +577,7 @@ jobs:
             rc=0
             waza run "${spec}" \
               --model "claude-sonnet-4.6" \
-              --judge-model "claude-sonnet-4.6" \
+              --judge-model "claude-opus-4.7" \
               --suggest \
               --recommend \
               --format "github-comment" \

--- a/website/docs/workflows/waza-evals.md
+++ b/website/docs/workflows/waza-evals.md
@@ -559,8 +559,19 @@ jobs:
           # task results, "Running benchmark:") streams to the runner log.
           # --model overrides the spec's config.model so we can fan out the
           # same eval suite across multiple models.
+          #
           # --judge-model decouples the LLM-as-judge from the executor model
-          # so quality scores are always judged by claude-opus-4.7.
+          # and pins it to claude-opus-4.7 for TWO reasons:
+          #   1. No self-grading bias — opus-4.7 is NOT in any matrix tier
+          #      (pilot: sonnet-4.6, gpt-5.4, gpt-5-codex, opus-4.6;
+          #      expanded: sonnet-4.6, gpt-5-codex), so no runner leg is
+          #      ever judged by its own model.
+          #   2. Judge capability ≥ every runner — opus-4.7 is chosen as a
+          #      higher-capability judge than the runner mix to reduce
+          #      ceiling effects when scoring the strongest runners.
+          # If a future tier ever adds opus-4.7 as a runner, the judge must
+          # be re-pinned to a model that is still outside the new roster.
+          #
           # --suggest --recommend appends outcome-tied recommendations.
           max_attempts=3
           attempt=0
@@ -915,7 +926,7 @@ jobs:
               '',
               '> **Legend:** Models flagged `baseline: true` in `.github/evals/manifest.yaml` (currently: `' +
                 (Array.from(baselineModels).join('`, `') || 'none') +
-                '`) run with `--baseline` (A/B mode) to cap quota. All other models run standard. Judge model is fixed at `claude-sonnet-4.6` across all legs.',
+                '`) run with `--baseline` (A/B mode) to cap quota. All other models run standard. Judge model is fixed at `claude-opus-4.7` across all legs.',
               '',
             ].filter((line) => line !== null).join('\n');
 

--- a/website/docs/workflows/waza-evals.md
+++ b/website/docs/workflows/waza-evals.md
@@ -560,7 +560,7 @@ jobs:
           # --model overrides the spec's config.model so we can fan out the
           # same eval suite across multiple models.
           # --judge-model decouples the LLM-as-judge from the executor model
-          # so quality scores are always judged by claude-sonnet-4.6.
+          # so quality scores are always judged by claude-opus-4.7.
           # --suggest --recommend appends outcome-tied recommendations.
           max_attempts=3
           attempt=0
@@ -572,7 +572,7 @@ jobs:
             # shellcheck disable=SC2086
             waza run "${spec}" \
               --model "${{ matrix.model }}" \
-              --judge-model "claude-sonnet-4.6" \
+              --judge-model "claude-opus-4.7" \
               --suggest \
               --recommend \
               ${extra_flags} \


### PR DESCRIPTION
## Summary

Pins the LLM-as-judge to `claude-opus-4.7` across every explicit `--judge-model` flag. The judge now sits **outside both runner rosters** (pilot: `sonnet-4.6`, `gpt-5.4`, `gpt-5.3-codex`, `opus-4.6`; expanded: `sonnet-4.6`, `gpt-5.3-codex`), so no leg is ever judged by its own model.

## Why

1. **No self-grading bias.** Previously `claude-sonnet-4.6` was both a runner and the judge, so its own legs had a built-in agreement floor that conflated capability with judge consensus. With `opus-4.7` (not in any roster) every leg gets an independent grader.
2. **Judge capability ≥ every runner.** `opus-4.7` strictly dominates the current runner mix on reasoning benchmarks, so it can score the strongest runner outputs without ceiling effects.

## Scope

| File | Change |
|------|--------|
| `.github/prompts/agent-promote.prompt.md` | flag + inline rationale |
| `.github/prompts/skill-promote.prompt.md` | flag + inline rationale |
| `.github/prompts/agent-onboard.prompt.md` | smoke-trial judge flag + note |
| `.github/prompts/skill-onboard.prompt.md` | smoke-trial judge flag + note |
| `.github/workflows/waza-evals.yml` | matrix step flag + expanded comment |
| `.github/workflows/waza-agent-evals.yml` | judge flag + expanded comment |

Every touched site now includes a comment explaining the two-reason rationale and a follow-up rule: **if a future tier ever adds `opus-4.7` as a runner, re-pin the judge to a model still outside the new roster.**

## Not touched (intentional)

- `.waza.yaml` `defaults.model` / `dev.model` — these are runner defaults, not the eval judge. `waza quality` (an advisory docs probe, not an eval grader) still uses this default.
- Runner models in `waza-agent-evals.yml` (`--model claude-sonnet-4.6`) — that's the agent's executor, unaffected by the judge swap.
- Tier rosters in `.github/evals/manifest.yaml` — runner sets unchanged.

## Verification

```bash
grep -rn 'judge-model' .github/prompts/ .github/workflows/waza-*.yml
```

All 5 `--judge-model` flag sites resolve to `claude-opus-4.7`; rationale comments/prose match.

## Risk

Low. Bench/promote runs will produce different absolute scores starting next run because the judge changed. Cross-model **relative** rankings should become more trustworthy (no roster member gets a self-grade boost). No runtime/code paths affected.