### PR TITLE
chore(release): bump to v0.2.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Git-Ape — Intelligent Azure deployment agent and skill suite for GitHub Copilot. Onboard any repository with guided ARM template generation, security analysis, cost estimation, drift detection, and automated CI/CD pipelines.",
-    "version": "0.1.1"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "git-ape",
       "description": "Intelligent Azure deployment agent system for GitHub Copilot. Provides guided, safe, and validated Azure resource deployments using ARM templates, with built-in security analysis, cost estimation, drift detection, and CI/CD pipeline integration.",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "source": "."
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [0.2.0] - 2026-06-10
+
+Changes since [v0.1.1](https://github.com/Azure/git-ape/releases/tag/v0.1.1):
+
+### Features
+
+- **skills:** emit partially-destroyed in local destroy scripts (`95dc3de`)
+- **extension:** register prompt files in VSIX and tighten .vscodeignore (`4b2a1b8`)
+- **onboarding:** replace exampleyml stubs with template-driven scaffold (`451686a`)
+- **skills:** refine azure-stack-deploy and azure-stack-destroy guidance (`904a7dd`)
+- **agents:** delegate to skills in deployer and template-generator (`a1d5633`)
+- add azure-stack-* skills with fast async destroy (`69113e4`)
+- implement Deployment Stacks for idempotent destroy + extended state schema (`79df223`)
+
+### Bug Fixes
+
+- **docs:** rewrite cross-skill SKILL.md links to resolvable slugs (`bc89221`)
+- **docs:** read AZURE_SUBSCRIPTION_ID from vars in agent and example workflows (`8c1ca1b`)
+- **workflows:** run release main-history guard for workflow_dispatch (`2bb671f`)
+- **onboarding:** set AZURE_SUBSCRIPTION_ID as a variable, not a secret (`de50e71`)
+- **onboarding:** sync copilot-instructions template with merged mirror (`e0ae84c`)
+- **workflows:** route parameters.json values through env to block injection (`dce5833`)
+- **onboarding:** remove /deploy comment trigger and fail loud on state push (`afb05ea`)
+- **onboarding:** harden scaffolded workflows against matrix.deployment_id injection (`59c303e`)
+- **workflows:** preserve FAILED counter in subscription resource cleanup (`236e840`)
+- **onboarding:** harden and correct scaffolded workflows (`d6b41dc`)
+- **workflows:** prevent shell and JS injection in deploy/destroy (`b2325f3`)
+- **skills:** resolve PR review findings for deployment stacks (`9f14080`)
+- **workflows:** address PR review findings (`9190c66`)
+- **workflows:** prevent post-tag release version drift (`702f01c`)
+- **plugin:** bump marketplace.json to 0.1.0 to match plugin.json (`6e017ab`)
+
+### Documentation
+
+- **website:** add companion page for git-ape-drift agentic workflow source (`e66e2ec`)
+- **website:** regenerate for templated workflows and prompt assets (`7137093`)
+- **instructions:** switch deploy/destroy guidance to Azure Deployment Stacks (`1fb61bd`)
+- **onboarding:** reconcile AZURE_SUBSCRIPTION_ID as a variable (`67005a7`)
+- drop /deploy comment trigger references (`d3cb045`)
+- regenerate agent and workflow docs after upstream merge (`98c6318`)
+- regenerate website docs from source (`4b07b5f`)
+
+### Chores
+
+- **models:** rename gpt-5-codex to gpt-5.3-codex across eval matrix (`8d5b9cf`)
+- **evals:** pin LLM-as-judge to claude-opus-4.7 to eliminate self-grading bias (`c263d48`)
+- **workflows:** recompile daily-repo-status lockfile against current source (`7a81254`)
+- **evals:** fix stale judge model in waza-evals PR comment header (`6f2d00b`)
+- **evals:** address PR review feedback on judge-model pin (`190887c`)
+- **actionlint:** exclude gh-aw compiler output from lint (`f364da5`)
+- regenerate gh-aw lock files with v0.76.1 (`175f81a`)
+
+### Dependencies
+
+- **website:** bump react group (`a56bcec`)
+- **actions:** bump github/gh-aw-actions (`2ee8546`)
+- **website:** bump js-yaml (`9cd63b0`)
+- **website:** bump @types/react (`8e75378`)
+
+### Tests
+
+- **evals:** add evals for azure-stack-deploy and azure-stack-destroy (`ed078a0`)
+
 ## [0.1.1] - 2026-05-28
 
 Changes since [v0.1.0](https://github.com/Azure/git-ape/releases/tag/v0.1.0):

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-ape",
   "description": "Intelligent agent system for deploying any Azure workload through GitHub Copilot. Provides guided, safe, and validated deployments using ARM templates, with built-in security analysis, cost estimation, and CI/CD pipeline integration.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/Azure/git-ape"

--- a/website/docs/reference/marketplace.md
+++ b/website/docs/reference/marketplace.md
@@ -17,12 +17,12 @@ The marketplace manifest configures how Git-Ape appears in the Copilot CLI plugi
 |-------|-------|
 | **Name** | git-ape |
 | **Owner** | Microsoft |
-| **Version** | 0.1.1 |
+| **Version** | 0.2.0 |
 | **Description** | Git-Ape — Intelligent Azure deployment agent and skill suite for GitHub Copilot. Onboard any repository with guided ARM template generation, security analysis, cost estimation, drift detection, and automated CI/CD pipelines. |
 
 ## Plugins
 
-- **git-ape** v0.1.1: Intelligent Azure deployment agent system for GitHub Copilot. Provides guided, safe, and validated Azure resource deployments using ARM templates, with built-in security analysis, cost estimation, drift detection, and CI/CD pipeline integration.
+- **git-ape** v0.2.0: Intelligent Azure deployment agent system for GitHub Copilot. Provides guided, safe, and validated Azure resource deployments using ARM templates, with built-in security analysis, cost estimation, drift detection, and CI/CD pipeline integration.
 - **ape-context** v1.0.0: Extension for git-ape that provides enhanced context management, allowing platform teams to set up a baseline for Engineering context, tools use & intent
 
 ## Full Source
@@ -36,13 +36,13 @@ The marketplace manifest configures how Git-Ape appears in the Copilot CLI plugi
   },
   "metadata": {
     "description": "Git-Ape — Intelligent Azure deployment agent and skill suite for GitHub Copilot. Onboard any repository with guided ARM template generation, security analysis, cost estimation, drift detection, and automated CI/CD pipelines.",
-    "version": "0.1.1"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "git-ape",
       "description": "Intelligent Azure deployment agent system for GitHub Copilot. Provides guided, safe, and validated Azure resource deployments using ARM templates, with built-in security analysis, cost estimation, drift detection, and CI/CD pipeline integration.",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "source": "."
     },
     {

--- a/website/docs/reference/plugin-json.md
+++ b/website/docs/reference/plugin-json.md
@@ -16,7 +16,7 @@ The plugin manifest defines the Git-Ape plugin metadata. The same manifest is co
 | Field | Value |
 |-------|-------|
 | **Name** | git-ape |
-| **Version** | 0.1.1 |
+| **Version** | 0.2.0 |
 | **Description** | Intelligent agent system for deploying any Azure workload through GitHub Copilot. Provides guided, safe, and validated deployments using ARM templates, with built-in security analysis, cost estimation, and CI/CD pipeline integration. |
 | **Author** | Microsoft |
 | **License** | MIT |
@@ -33,7 +33,7 @@ The plugin manifest defines the Git-Ape plugin metadata. The same manifest is co
 {
   "name": "git-ape",
   "description": "Intelligent agent system for deploying any Azure workload through GitHub Copilot. Provides guided, safe, and validated deployments using ARM templates, with built-in security analysis, cost estimation, and CI/CD pipeline integration.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/Azure/git-ape"


### PR DESCRIPTION
## Release 0.2.0 Prep

Bumps version files to `0.2.0` and adds the changelog entry so the release workflow invariant passes.

### Changes
- `plugin.json` version: `0.1.1` → `0.2.0`
- `.github/plugin/marketplace.json` metadata + plugin entry version: `0.1.1` → `0.2.0`
- `CHANGELOG.md`: new `[0.2.0] - 2026-06-10` section (7 features, 15 bug fixes, 7 docs, 7 chores, 4 deps, 1 test)

### After merge
Tag and release:
```bash
git checkout main && git pull
git tag -a v0.2.0 -m "Release v0.2.0"
git push origin v0.2.0
```
Or use **Actions → Git-Ape: Plugin Release → Run workflow** with version `0.2.0`.