### PR TITLE
Add lint + parse CI gate for skill shell/PowerShell scripts

### DIFF
--- a/.github/linters/PSScriptAnalyzerSettings.psd1
+++ b/.github/linters/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,22 @@
+@{
+    # PSScriptAnalyzer settings for the PowerShell scripts embedded in Git-Ape
+    # skills (.github/skills/**/*.ps1). Enforced by the "Git-Ape: Script Lint"
+    # workflow (.github/workflows/git-ape-script-lint.yml).
+    #
+    # The gate fails on any finding at Error or Warning severity. Two rules are
+    # excluded because they are inappropriate for these scripts:
+    Severity = @('Error', 'Warning')
+
+    ExcludeRules = @(
+        # Skill scripts are interactive CLI tools whose whole job is to print
+        # human-readable status (checkmarks, warnings, progress) to the console.
+        # Write-Host is the correct call here, not a design smell.
+        'PSAvoidUsingWriteHost'
+
+        # These scripts emit emoji and box-drawing characters and are invoked
+        # cross-platform (bash + pwsh). A UTF-8 BOM is undesirable on Linux/macOS
+        # and would break the byte-for-byte scaffold parity check in
+        # git-ape-onboarding-template-check.yml, so files are kept BOM-less.
+        'PSUseBOMForUnicodeEncodedFile'
+    )
+}

--- a/.github/skills/azure-drift-detector/scripts/detect-drift.sh
+++ b/.github/skills/azure-drift-detector/scripts/detect-drift.sh
@@ -61,6 +61,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --verbose)
+            # shellcheck disable=SC2034  # reserved: --verbose is accepted for CLI parity; verbose output is not yet wired up
             VERBOSE=true
             shift
             ;;
@@ -114,11 +115,8 @@ echo ""
 # Load known drift if exists and ignoring is enabled
 KNOWN_DRIFT_FILE="$DRIFT_DIR/known-drift.json"
 if [[ "$IGNORE_KNOWN_DRIFT" == "true" ]] && [[ -f "$KNOWN_DRIFT_FILE" ]]; then
-    KNOWN_DRIFT=$(cat "$KNOWN_DRIFT_FILE")
     echo -e "${YELLOW}Note: Ignoring known drift entries${NC}"
     echo ""
-else
-    KNOWN_DRIFT="{}"
 fi
 
 # Initialize drift counters

--- a/.github/skills/azure-drift-detector/scripts/drift-check-all.sh
+++ b/.github/skills/azure-drift-detector/scripts/drift-check-all.sh
@@ -110,11 +110,12 @@ for DEPLOYMENT_PATH in $DEPLOYMENTS; do
     [[ "$VERBOSE" == "true" ]] && echo -e "${BLUE}Checking: $DEPLOYMENT_ID${NC}"
     
     # Run drift detection
-    DRIFT_ARGS="--deployment-id $DEPLOYMENT_ID --output-format json"
-    [[ "$INCLUDE_KNOWN" == "true" ]] && DRIFT_ARGS="$DRIFT_ARGS --include-known-drift"
+    DRIFT_ARGS=(--deployment-id "$DEPLOYMENT_ID" --output-format json)
+    [[ "$INCLUDE_KNOWN" == "true" ]] && DRIFT_ARGS+=(--include-known-drift)
     
-    DRIFT_OUTPUT=$("$SCRIPT_DIR/detect-drift.sh" $DRIFT_ARGS 2>&1 || true)
-    DRIFT_EXIT_CODE=$?
+    # Drift results are parsed from the JSON file written below, so stdout/stderr
+    # from the detector are intentionally discarded here.
+    "$SCRIPT_DIR/detect-drift.sh" "${DRIFT_ARGS[@]}" >/dev/null 2>&1 || true
     
     # Parse drift results
     DRIFT_FILE="$DEPLOYMENT_PATH/drift-analysis/drift-details.json"

--- a/.github/skills/azure-stack-deploy/scripts/deploy-stack.ps1
+++ b/.github/skills/azure-stack-deploy/scripts/deploy-stack.ps1
@@ -124,7 +124,7 @@ function Get-ResourceClassification {
     }
 }
 
-function Build-ManagedResources {
+function Build-ManagedResource {
     param([string[]]$ResourceIds)
     $list = @()
     foreach ($id in $ResourceIds) {
@@ -272,7 +272,7 @@ if ($DeployMethod -eq 'stack' -and $StackId) {
     $resourceIds = if ($opsTsv) { $opsTsv -split "`n" | Where-Object { $_ } } else { @() }
 }
 
-$ManagedResources = Build-ManagedResources -ResourceIds $resourceIds
+$ManagedResources = Build-ManagedResource -ResourceIds $resourceIds
 $ResourceGroups   = @($ManagedResources | ForEach-Object {
     if ($_.id -match '/resourceGroups/([^/]+)') { $matches[1] }
 } | Sort-Object -Unique)

--- a/.github/skills/prereq-check/scripts/check-tools.ps1
+++ b/.github/skills/prereq-check/scripts/check-tools.ps1
@@ -27,24 +27,24 @@ function Test-VersionAtLeast {
     }
 }
 
-function Emit-Row {
+function Write-Row {
     param([string]$Tool, [string]$Status, [string]$Found)
     "{0}`t{1}`t{2}`t{3}" -f $Tool, $Status, $Found, $min[$Tool]
 }
 
-function Check-Tool {
+function Test-Tool {
     param([string]$Tool, [scriptblock]$Extract)
     if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) {
-        Emit-Row $Tool 'MISSING' '-'
+        Write-Row $Tool 'MISSING' '-'
         return
     }
     $found = ''
     try { $found = (& $Extract) } catch { $found = '' }
     if (-not $found) { $found = 'unknown' }
     if ($min[$Tool] -ne '0' -and -not (Test-VersionAtLeast $found $min[$Tool])) {
-        Emit-Row $Tool 'OUTDATED' $found
+        Write-Row $Tool 'OUTDATED' $found
     } else {
-        Emit-Row $Tool 'OK' $found
+        Write-Row $Tool 'OK' $found
     }
 }
 
@@ -56,22 +56,22 @@ $arch = if ($env:PROCESSOR_ARCHITECTURE) {
 }
 "Platform: $os / $arch"
 
-Check-Tool 'az' {
+Test-Tool 'az' {
     # Avoid `--query '"azure-cli"'` — PowerShell's native-command parser strips
     # the inner double-quotes, leaving JMESPath with an unquoted hyphenated
     # identifier (`azure-cli`) that fails to parse. Parse JSON instead.
     $v = az version -o json 2>$null | ConvertFrom-Json
     if ($v) { $v.'azure-cli' } else { '' }
 }
-Check-Tool 'gh' {
+Test-Tool 'gh' {
     $line = (gh --version 2>$null | Select-Object -First 1)
     if ($line -match '\d+\.\d+\.\d+') { $matches[0] } else { '' }
 }
-Check-Tool 'jq' {
+Test-Tool 'jq' {
     $v = (jq --version 2>$null)
     if ($v -match '\d+\.\d+[a-z]*') { $matches[0] } else { '' }
 }
-Check-Tool 'git' {
+Test-Tool 'git' {
     $v = (git --version 2>$null)
     if ($v -match '\d+\.\d+\.\d+') { $matches[0] } else { '' }
 }

--- a/.github/workflows/git-ape-script-lint.yml
+++ b/.github/workflows/git-ape-script-lint.yml
@@ -1,0 +1,147 @@
+name: "Git-Ape: Script Lint"
+
+# Static analysis + parse gate for the shell and PowerShell scripts embedded in
+# Git-Ape skills (.github/skills/**). This is the L0+L1 layer of the script
+# testing strategy:
+#   L0 - lint:  shellcheck (.sh) and PSScriptAnalyzer (.ps1)
+#   L1 - parse: bash -n (.sh) and the PowerShell language parser (.ps1)
+#
+# Both jobs are static — they need neither Azure credentials nor a live
+# subscription, so they run on every matching PR in seconds.
+#
+# Severity policy:
+#   * shellcheck gates at --severity=warning (errors + warnings block;
+#     info/style findings are surfaced by the dedicated audit step but do
+#     not fail the build).
+#   * PSScriptAnalyzer gates on Error + Warning via
+#     .github/linters/PSScriptAnalyzerSettings.psd1 (which documents the two
+#     intentionally-excluded rules).
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**/*.sh'
+      - '.github/skills/**/*.ps1'
+      - '.github/linters/PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/git-ape-script-lint.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  shell-lint:
+    name: Shell scripts (shellcheck + bash -n)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure shellcheck is available
+        run: |
+          set -euo pipefail
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+          fi
+          shellcheck --version
+
+      - name: Lint and parse-check shell scripts
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(find .github/skills -type f -name '*.sh' | sort)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No skill shell scripts found."
+            exit 0
+          fi
+          echo "Found ${#FILES[@]} shell script(s):"
+          printf '  %s\n' "${FILES[@]}"
+
+          echo "::group::Syntax check (bash -n)"
+          syntax_rc=0
+          for f in "${FILES[@]}"; do
+            if bash -n "$f"; then
+              echo "ok   $f"
+            else
+              echo "FAIL $f"
+              syntax_rc=1
+            fi
+          done
+          echo "::endgroup::"
+          if [ "$syntax_rc" -ne 0 ]; then
+            echo "::error::One or more shell scripts failed 'bash -n' syntax check."
+            exit 1
+          fi
+
+          echo "::group::ShellCheck (severity=warning, gating)"
+          shellcheck --severity=warning --color=always "${FILES[@]}"
+          echo "All scripts passed shellcheck at severity=warning."
+          echo "::endgroup::"
+
+          echo "::group::ShellCheck info/style audit (non-gating)"
+          shellcheck --severity=style --color=always "${FILES[@]}" || true
+          echo "::endgroup::"
+
+  pwsh-lint:
+    name: PowerShell scripts (PSScriptAnalyzer + parser)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+            Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+          }
+          $v = (Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1).Version
+          Write-Host "PSScriptAnalyzer $v"
+
+      - name: Lint and parse-check PowerShell scripts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = Get-ChildItem -Recurse -Path .github/skills -Filter *.ps1 | Sort-Object FullName
+          if (-not $files) {
+            Write-Host 'No skill PowerShell scripts found.'
+            exit 0
+          }
+          Write-Host ("Found {0} PowerShell script(s):" -f @($files).Count)
+          $files | ForEach-Object { Write-Host "  $($_.FullName)" }
+
+          # --- L1: parser gate ---
+          Write-Host '::group::Parser gate'
+          $parseFail = 0
+          foreach ($f in $files) {
+            $errs = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($f.FullName, [ref]$null, [ref]$errs) | Out-Null
+            if ($errs -and $errs.Count -gt 0) {
+              $parseFail = 1
+              Write-Host "::error file=$($f.FullName)::$($errs.Count) parse error(s)"
+              $errs | ForEach-Object { Write-Host "    $($_.Message)" }
+            } else {
+              Write-Host "ok   $($f.FullName)"
+            }
+          }
+          Write-Host '::endgroup::'
+          if ($parseFail -ne 0) {
+            Write-Host '::error::One or more PowerShell scripts failed to parse.'
+            exit 1
+          }
+
+          # --- L0: PSScriptAnalyzer gate ---
+          Write-Host '::group::PSScriptAnalyzer (Error + Warning, gating)'
+          $settings = '.github/linters/PSScriptAnalyzerSettings.psd1'
+          $results = $files | ForEach-Object { Invoke-ScriptAnalyzer -Path $_.FullName -Settings $settings }
+          if ($results) {
+            $results |
+              Sort-Object Severity, ScriptName, Line |
+              Format-Table Severity, RuleName, @{ n = 'File'; e = { Split-Path $_.ScriptName -Leaf } }, Line, Message -AutoSize -Wrap |
+              Out-String -Width 200 |
+              Write-Host
+            Write-Host "::error::PSScriptAnalyzer reported $(@($results).Count) finding(s) at Error/Warning severity."
+            exit 1
+          }
+          Write-Host 'All scripts passed PSScriptAnalyzer at Error/Warning severity.'
+          Write-Host '::endgroup::'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,13 @@ site. Decision rationale for the harness choice lives in
    - Cross-references (slash-commands `/skill-name`) map to existing skill directories
    - Relative markdown links resolve to real file paths
    - Markdown passes linting (markdownlint)
+
+   If your PR touches a skill's shell or PowerShell scripts, the separate
+   **Script Lint** workflow (`git-ape-script-lint.yml`) also runs:
+   - Shell scripts (`.sh`) must pass `shellcheck` (severity ≥ warning) and `bash -n`
+   - PowerShell scripts (`.ps1`) must pass `PSScriptAnalyzer` (Error/Warning, per
+     [`.github/linters/PSScriptAnalyzerSettings.psd1`](.github/linters/PSScriptAnalyzerSettings.psd1))
+     and the PowerShell language parser
 6. **Review** — Maintainers will review your PR and provide feedback.
 
 ## Development Setup
@@ -151,6 +158,20 @@ node scripts/validate-structure.js
 
 # Generate documentation (optional)
 node scripts/generate-docs.js
+```
+
+If you edit a skill's embedded scripts, reproduce the **Script Lint** checks
+locally before pushing:
+
+```bash
+# Shell: static analysis + syntax (needs shellcheck + bash)
+find .github/skills -name '*.sh' -print0 | xargs -0 shellcheck --severity=warning
+find .github/skills -name '*.sh' -exec bash -n {} \;
+
+# PowerShell: static analysis + parser (needs pwsh + PSScriptAnalyzer)
+pwsh -NoProfile -Command "Install-Module PSScriptAnalyzer -Scope CurrentUser -Force"
+pwsh -NoProfile -Command "Get-ChildItem -Recurse .github/skills -Filter *.ps1 |
+  ForEach-Object { Invoke-ScriptAnalyzer -Path \$_.FullName -Settings .github/linters/PSScriptAnalyzerSettings.psd1 }"
 ```
 
 ## Reporting Issues

--- a/website/docs/workflows/git-ape-script-lint.md
+++ b/website/docs/workflows/git-ape-script-lint.md
@@ -1,0 +1,200 @@
+---
+title: "Git-Ape: Script Lint"
+sidebar_label: "Script Lint"
+description: "GitHub Actions workflow: Git-Ape: Script Lint"
+---
+
+<!-- AUTO-GENERATED — DO NOT EDIT. Source: .github/workflows/git-ape-script-lint.yml -->
+
+
+# Git-Ape: Script Lint
+
+**Workflow file:** `.github/workflows/git-ape-script-lint.yml`
+
+## Triggers
+
+- **`pull_request`** — paths: `.github/skills/**/*.sh, .github/skills/**/*.ps1, .github/linters/PSScriptAnalyzerSettings.psd1...`
+- **`workflow_dispatch`**
+
+
+## Permissions
+
+- `contents: read`
+
+## Jobs
+
+### `shell-lint`
+
+| Property | Value |
+|----------|-------|
+| **Display Name** | Shell scripts (shellcheck + bash -n) |
+| **Runs On** | `ubuntu-latest` |
+| **Steps** | 3 |
+
+### `pwsh-lint`
+
+| Property | Value |
+|----------|-------|
+| **Display Name** | PowerShell scripts (PSScriptAnalyzer + parser) |
+| **Runs On** | `ubuntu-latest` |
+| **Steps** | 3 |
+
+
+
+## Source
+
+<details>
+<summary>Click to view full workflow YAML</summary>
+
+```yaml
+name: "Git-Ape: Script Lint"
+
+# Static analysis + parse gate for the shell and PowerShell scripts embedded in
+# Git-Ape skills (.github/skills/**). This is the L0+L1 layer of the script
+# testing strategy:
+#   L0 - lint:  shellcheck (.sh) and PSScriptAnalyzer (.ps1)
+#   L1 - parse: bash -n (.sh) and the PowerShell language parser (.ps1)
+#
+# Both jobs are static — they need neither Azure credentials nor a live
+# subscription, so they run on every matching PR in seconds.
+#
+# Severity policy:
+#   * shellcheck gates at --severity=warning (errors + warnings block;
+#     info/style findings are surfaced by the dedicated audit step but do
+#     not fail the build).
+#   * PSScriptAnalyzer gates on Error + Warning via
+#     .github/linters/PSScriptAnalyzerSettings.psd1 (which documents the two
+#     intentionally-excluded rules).
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**/*.sh'
+      - '.github/skills/**/*.ps1'
+      - '.github/linters/PSScriptAnalyzerSettings.psd1'
+      - '.github/workflows/git-ape-script-lint.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  shell-lint:
+    name: Shell scripts (shellcheck + bash -n)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure shellcheck is available
+        run: |
+          set -euo pipefail
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y shellcheck
+          fi
+          shellcheck --version
+
+      - name: Lint and parse-check shell scripts
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(find .github/skills -type f -name '*.sh' | sort)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No skill shell scripts found."
+            exit 0
+          fi
+          echo "Found ${#FILES[@]} shell script(s):"
+          printf '  %s\n' "${FILES[@]}"
+
+          echo "::group::Syntax check (bash -n)"
+          syntax_rc=0
+          for f in "${FILES[@]}"; do
+            if bash -n "$f"; then
+              echo "ok   $f"
+            else
+              echo "FAIL $f"
+              syntax_rc=1
+            fi
+          done
+          echo "::endgroup::"
+          if [ "$syntax_rc" -ne 0 ]; then
+            echo "::error::One or more shell scripts failed 'bash -n' syntax check."
+            exit 1
+          fi
+
+          echo "::group::ShellCheck (severity=warning, gating)"
+          shellcheck --severity=warning --color=always "${FILES[@]}"
+          echo "All scripts passed shellcheck at severity=warning."
+          echo "::endgroup::"
+
+          echo "::group::ShellCheck info/style audit (non-gating)"
+          shellcheck --severity=style --color=always "${FILES[@]}" || true
+          echo "::endgroup::"
+
+  pwsh-lint:
+    name: PowerShell scripts (PSScriptAnalyzer + parser)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+            Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+          }
+          $v = (Get-Module -ListAvailable -Name PSScriptAnalyzer | Select-Object -First 1).Version
+          Write-Host "PSScriptAnalyzer $v"
+
+      - name: Lint and parse-check PowerShell scripts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $files = Get-ChildItem -Recurse -Path .github/skills -Filter *.ps1 | Sort-Object FullName
+          if (-not $files) {
+            Write-Host 'No skill PowerShell scripts found.'
+            exit 0
+          }
+          Write-Host ("Found {0} PowerShell script(s):" -f @($files).Count)
+          $files | ForEach-Object { Write-Host "  $($_.FullName)" }
+
+          # --- L1: parser gate ---
+          Write-Host '::group::Parser gate'
+          $parseFail = 0
+          foreach ($f in $files) {
+            $errs = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($f.FullName, [ref]$null, [ref]$errs) | Out-Null
+            if ($errs -and $errs.Count -gt 0) {
+              $parseFail = 1
+              Write-Host "::error file=$($f.FullName)::$($errs.Count) parse error(s)"
+              $errs | ForEach-Object { Write-Host "    $($_.Message)" }
+            } else {
+              Write-Host "ok   $($f.FullName)"
+            }
+          }
+          Write-Host '::endgroup::'
+          if ($parseFail -ne 0) {
+            Write-Host '::error::One or more PowerShell scripts failed to parse.'
+            exit 1
+          }
+
+          # --- L0: PSScriptAnalyzer gate ---
+          Write-Host '::group::PSScriptAnalyzer (Error + Warning, gating)'
+          $settings = '.github/linters/PSScriptAnalyzerSettings.psd1'
+          $results = $files | ForEach-Object { Invoke-ScriptAnalyzer -Path $_.FullName -Settings $settings }
+          if ($results) {
+            $results |
+              Sort-Object Severity, ScriptName, Line |
+              Format-Table Severity, RuleName, @{ n = 'File'; e = { Split-Path $_.ScriptName -Leaf } }, Line, Message -AutoSize -Wrap |
+              Out-String -Width 200 |
+              Write-Host
+            Write-Host "::error::PSScriptAnalyzer reported $(@($results).Count) finding(s) at Error/Warning severity."
+            exit 1
+          }
+          Write-Host 'All scripts passed PSScriptAnalyzer at Error/Warning severity.'
+          Write-Host '::endgroup::'
+
+```
+
+</details>

--- a/website/docs/workflows/overview.md
+++ b/website/docs/workflows/overview.md
@@ -38,6 +38,7 @@ The user-facing workflows below are **shipped as templates** under `.github/skil
 | [Git-Ape: Onboarding Template Check](./git-ape-onboarding-template-check) | `.github/workflows/git-ape-onboarding-template-check.yml` | pull_request, workflow_dispatch | check-sync-bash, check-sync-pwsh, scaffold-parity-smoke |
 | [Git-Ape: Plugin Version Check](./git-ape-plugin-version-check) | `.github/workflows/git-ape-plugin-version-check.yml` | pull_request | check-version-drift |
 | [Git-Ape: Plugin Release](./git-ape-release) | `.github/workflows/git-ape-release.yml` | push, workflow_dispatch | release |
+| [Git-Ape: Script Lint](./git-ape-script-lint) | `.github/workflows/git-ape-script-lint.yml` | pull_request, workflow_dispatch | shell-lint, pwsh-lint |
 | [Issue Triage Agent](./issue-triage-agent-lock) | `.github/workflows/issue-triage-agent.lock.yml` | schedule, workflow_dispatch | activation, agent, conclusion, detection, safe_outputs |
 | [PR Validation](./pr-validation) | `.github/workflows/pr-validation.yml` | pull_request | structure-check, markdownlint |
 | [Waza agent evals](./waza-agent-evals) | `.github/workflows/waza-agent-evals.yml` | pull_request, workflow_dispatch | preflight, prepare, tokens, eval, comment |


### PR DESCRIPTION
## What

Adds a single CI workflow that statically lints **every embedded skill script** under `.github/skills/**`. Until now these `.sh` and `.ps1` files had no automated coverage — the only script test in the repo is the onboarding scaffold sync/parity check.

## The gate — `git-ape-script-lint.yml`

Two jobs, both `ubuntu-latest`, both static (no Azure):

- **`shell-lint`** — `bash -n` (parse) + `shellcheck --severity=warning` on all `.sh`, plus a non-gating `--severity=style` audit for visibility.
- **`pwsh-lint`** — PowerShell language-parser check + `PSScriptAnalyzer` (Error/Warning) on all `.ps1`, configured via [`.github/linters/PSScriptAnalyzerSettings.psd1`](.github/linters/PSScriptAnalyzerSettings.psd1).

Triggers on PRs touching skill `.sh`/`.ps1`, the settings file, or the workflow itself; plus `workflow_dispatch`.

## Rule exclusions (documented, intentional)

The PSScriptAnalyzer settings exclude two rules with rationale in-file:
- **`PSAvoidUsingWriteHost`** — these are interactive CLI tools that legitimately print to the console.
- **`PSUseBOMForUnicodeEncodedFile`** — a BOM would break the existing byte-for-byte `scaffold-parity-smoke` check and is undesirable cross-platform.

## Fixes to make the gate pass (no rules weakened)

Rather than suppress real findings, the underlying issues were fixed:

| File | Fix |
|------|-----|
| `detect-drift.sh` | remove dead `VERBOSE`/`KNOWN_DRIFT` (SC2034) |
| `drift-check-all.sh` | drop dead capture, convert `DRIFT_ARGS` to a bash array (SC2034 + SC2086) |
| `check-tools.ps1` | `Emit-Row`→`Write-Row`, `Check-Tool`→`Test-Tool` (PSUseApprovedVerbs) — TSV output contract unchanged |
| `deploy-stack.ps1` | `Build-ManagedResources`→`Build-ManagedResource` (PSUseSingularNouns) |

## Docs

`CONTRIBUTING.md` documents the new checks and the exact commands to reproduce them locally.

## Scope

Intentionally scoped to `.github/skills/**` (the "skill scripts"). `.github/scripts/deployment-manager.sh` is the obvious next file to bring under the gate — it first needs an `SC2045` fix. Behavioral/parity tests (bats + Pester, generalizing the onboarding `scaffold-parity-smoke` pattern) remain a possible follow-up.

## Verification

All gates verified green locally before commit: `bash -n` ✅, `shellcheck --severity=warning` ✅, PowerShell parser ✅ (0 errors), `PSScriptAnalyzer` ✅ (0 findings), `actionlint` on the new workflow ✅, `markdownlint` on `CONTRIBUTING.md` ✅.