### PR TITLE
fix(deploy): stop --verbose output corrupting deploy JSON parsed by jq

### DIFF
--- a/.github/skills/git-ape-onboarding/templates/workflows/git-ape-deploy.yml
+++ b/.github/skills/git-ape-onboarding/templates/workflows/git-ape-deploy.yml
@@ -259,9 +259,11 @@ jobs:
           # Default Azure CLI output to JSON. The --verbose diagnostics below are
           # written to stderr; capture them in a temp file so they don't get mixed
           # into the JSON on stdout that we parse with jq (which would otherwise
-          # crash this step on an otherwise-successful deploy).
+          # crash this step on an otherwise-successful deploy). The trap guarantees
+          # the temp file is removed when the step exits, however it ends.
           export AZURE_CORE_OUTPUT=json
           VERBOSE_LOG=$(mktemp)
+          trap 'rm -f "$VERBOSE_LOG"' EXIT
 
           # Create/update the subscription-scope Deployment Stack.
           # --action-on-unmanage deleteAll binds the whole stack (RG + contents)
@@ -292,7 +294,6 @@ jobs:
             # The real error is on stderr (captured in VERBOSE_LOG); stdout
             # (DEPLOY_OUTPUT) is usually empty on failure. Surface both.
             VERBOSE_CONTENT=$(cat "$VERBOSE_LOG")
-            rm -f "$VERBOSE_LOG"
             echo "deploy_status=failed" >> "$GITHUB_OUTPUT"
             echo "deploy_error<<EOF" >> "$GITHUB_OUTPUT"
             echo "$DEPLOY_OUTPUT" >> "$GITHUB_OUTPUT"
@@ -323,10 +324,6 @@ jobs:
             echo "::error::Stack deployment failed — see output above for details"
             exit 1
           fi
-
-          # Success: stdout was clean JSON, so the verbose stderr log is no longer
-          # needed. Remove it before parsing the deploy output below.
-          rm -f "$VERBOSE_LOG"
 
           echo "deploy_status=succeeded" >> "$GITHUB_OUTPUT"
 

--- a/.github/skills/git-ape-onboarding/templates/workflows/git-ape-deploy.yml
+++ b/.github/skills/git-ape-onboarding/templates/workflows/git-ape-deploy.yml
@@ -256,8 +256,12 @@ jobs:
           echo "    prior stack : ${{ steps.pre_state.outputs.stack_existed }}"
           START_TIME=$(date +%s)
 
-          # Enable verbose Azure CLI logging for this step
+          # Default Azure CLI output to JSON. The --verbose diagnostics below are
+          # written to stderr; capture them in a temp file so they don't get mixed
+          # into the JSON on stdout that we parse with jq (which would otherwise
+          # crash this step on an otherwise-successful deploy).
           export AZURE_CORE_OUTPUT=json
+          VERBOSE_LOG=$(mktemp)
 
           # Create/update the subscription-scope Deployment Stack.
           # --action-on-unmanage deleteAll binds the whole stack (RG + contents)
@@ -274,7 +278,7 @@ jobs:
             --tags "managedBy=git-ape" "deploymentId=$STACK_NAME" \
             --yes \
             --verbose \
-            --output json 2>&1)
+            --output json 2>"$VERBOSE_LOG")
           EXIT_CODE=$?
           set -e
 
@@ -285,15 +289,21 @@ jobs:
           echo "::endgroup::"
 
           if [[ $EXIT_CODE -ne 0 ]]; then
+            # The real error is on stderr (captured in VERBOSE_LOG); stdout
+            # (DEPLOY_OUTPUT) is usually empty on failure. Surface both.
+            VERBOSE_CONTENT=$(cat "$VERBOSE_LOG")
+            rm -f "$VERBOSE_LOG"
             echo "deploy_status=failed" >> "$GITHUB_OUTPUT"
             echo "deploy_error<<EOF" >> "$GITHUB_OUTPUT"
             echo "$DEPLOY_OUTPUT" >> "$GITHUB_OUTPUT"
+            echo "$VERBOSE_CONTENT" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
             echo ""
             echo "=========================================="
             echo "❌ STACK DEPLOYMENT FAILED"
             echo "=========================================="
             echo "$DEPLOY_OUTPUT"
+            echo "$VERBOSE_CONTENT"
             echo "=========================================="
 
             # Surface the underlying deployment operation errors — the stack error
@@ -313,6 +323,10 @@ jobs:
             echo "::error::Stack deployment failed — see output above for details"
             exit 1
           fi
+
+          # Success: stdout was clean JSON, so the verbose stderr log is no longer
+          # needed. Remove it before parsing the deploy output below.
+          rm -f "$VERBOSE_LOG"
 
           echo "deploy_status=succeeded" >> "$GITHUB_OUTPUT"
 

--- a/website/docs/workflows/git-ape-deploy.md
+++ b/website/docs/workflows/git-ape-deploy.md
@@ -315,8 +315,12 @@ jobs:
           echo "    prior stack : ${{ steps.pre_state.outputs.stack_existed }}"
           START_TIME=$(date +%s)
 
-          # Enable verbose Azure CLI logging for this step
+          # Default Azure CLI output to JSON. The --verbose diagnostics below are
+          # written to stderr; capture them in a temp file so they don't get mixed
+          # into the JSON on stdout that we parse with jq (which would otherwise
+          # crash this step on an otherwise-successful deploy).
           export AZURE_CORE_OUTPUT=json
+          VERBOSE_LOG=$(mktemp)
 
           # Create/update the subscription-scope Deployment Stack.
           # --action-on-unmanage deleteAll binds the whole stack (RG + contents)
@@ -333,7 +337,7 @@ jobs:
             --tags "managedBy=git-ape" "deploymentId=$STACK_NAME" \
             --yes \
             --verbose \
-            --output json 2>&1)
+            --output json 2>"$VERBOSE_LOG")
           EXIT_CODE=$?
           set -e
 
@@ -344,15 +348,21 @@ jobs:
           echo "::endgroup::"
 
           if [[ $EXIT_CODE -ne 0 ]]; then
+            # The real error is on stderr (captured in VERBOSE_LOG); stdout
+            # (DEPLOY_OUTPUT) is usually empty on failure. Surface both.
+            VERBOSE_CONTENT=$(cat "$VERBOSE_LOG")
+            rm -f "$VERBOSE_LOG"
             echo "deploy_status=failed" >> "$GITHUB_OUTPUT"
             echo "deploy_error<<EOF" >> "$GITHUB_OUTPUT"
             echo "$DEPLOY_OUTPUT" >> "$GITHUB_OUTPUT"
+            echo "$VERBOSE_CONTENT" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
             echo ""
             echo "=========================================="
             echo "❌ STACK DEPLOYMENT FAILED"
             echo "=========================================="
             echo "$DEPLOY_OUTPUT"
+            echo "$VERBOSE_CONTENT"
             echo "=========================================="
 
             # Surface the underlying deployment operation errors — the stack error
@@ -372,6 +382,10 @@ jobs:
             echo "::error::Stack deployment failed — see output above for details"
             exit 1
           fi
+
+          # Success: stdout was clean JSON, so the verbose stderr log is no longer
+          # needed. Remove it before parsing the deploy output below.
+          rm -f "$VERBOSE_LOG"
 
           echo "deploy_status=succeeded" >> "$GITHUB_OUTPUT"
 

--- a/website/docs/workflows/git-ape-deploy.md
+++ b/website/docs/workflows/git-ape-deploy.md
@@ -318,9 +318,11 @@ jobs:
           # Default Azure CLI output to JSON. The --verbose diagnostics below are
           # written to stderr; capture them in a temp file so they don't get mixed
           # into the JSON on stdout that we parse with jq (which would otherwise
-          # crash this step on an otherwise-successful deploy).
+          # crash this step on an otherwise-successful deploy). The trap guarantees
+          # the temp file is removed when the step exits, however it ends.
           export AZURE_CORE_OUTPUT=json
           VERBOSE_LOG=$(mktemp)
+          trap 'rm -f "$VERBOSE_LOG"' EXIT
 
           # Create/update the subscription-scope Deployment Stack.
           # --action-on-unmanage deleteAll binds the whole stack (RG + contents)
@@ -351,7 +353,6 @@ jobs:
             # The real error is on stderr (captured in VERBOSE_LOG); stdout
             # (DEPLOY_OUTPUT) is usually empty on failure. Surface both.
             VERBOSE_CONTENT=$(cat "$VERBOSE_LOG")
-            rm -f "$VERBOSE_LOG"
             echo "deploy_status=failed" >> "$GITHUB_OUTPUT"
             echo "deploy_error<<EOF" >> "$GITHUB_OUTPUT"
             echo "$DEPLOY_OUTPUT" >> "$GITHUB_OUTPUT"
@@ -382,10 +383,6 @@ jobs:
             echo "::error::Stack deployment failed — see output above for details"
             exit 1
           fi
-
-          # Success: stdout was clean JSON, so the verbose stderr log is no longer
-          # needed. Remove it before parsing the deploy output below.
-          rm -f "$VERBOSE_LOG"
 
           echo "deploy_status=succeeded" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Fixes the `git-ape-deploy` workflow crashing **after** a successful Azure deployment.

Closes #185

## Problem

The deploy step captured `az stack sub create --verbose --output json 2>&1`. `--verbose` writes diagnostics to **stderr**, and `2>&1` merged them into `DEPLOY_OUTPUT` alongside the result JSON on **stdout**. On a **successful** deploy the captured value started with verbose log text, so the next `jq -r '.id'` failed:

```
[08:03:47] az stack sub create exited with code 0 after 177s
jq: parse error: Invalid numeric literal at line 1, column 5
Error: Process completed with exit code 5.
```

Under `bash -e` the failed `jq` aborted the step (exit 5) even though Azure had already created the stack — leaving the deployment untracked (no `state.json` committed).

## Fix

Redirect stderr to a temp file (`2>"$VERBOSE_LOG"`) so stdout stays pure JSON — the same pattern the standalone `deploy-stack.sh` skill already uses. On failure the verbose log is read back and surfaced in both the step log and the `deploy_error` output; on success the temp file is removed before parsing.

## Changes

- `.github/skills/git-ape-onboarding/templates/workflows/git-ape-deploy.yml`
- `website/docs/workflows/git-ape-deploy.md` (docs mirror, kept in sync)

## Validation

- `actionlint` (with shellcheck): no new findings — identical 6 pre-existing `SC2129` style nits before and after.
- YAML parses; `2>&1` removed from the deploy-create capture; both files consistent.

## Note for existing deployments

This fixes the **template**. Repos already onboarded (e.g. `git-ape-demo`) carry the previously generated workflow and need this patch applied (re-run onboarding or cherry-pick). The earlier `deploy-20260615-154802` run **did deploy successfully** in `southeastasia` — only post-deploy parsing crashed.