### PR TITLE
Add optional drift-detector onboarding to git-ape-onboarding

### DIFF
--- a/.github/skills/git-ape-onboarding/SKILL.md
+++ b/.github/skills/git-ape-onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-ape-onboarding
-description: "Onboard a repository, Azure subscription(s), and user identity for Git-Ape CI/CD using a skill-driven CLI playbook. Use for first-time setup of OIDC, federated credentials, RBAC, GitHub environments, and required secrets."
+description: "Bootstrap a GitHub repository for Git-Ape CI/CD: Entra app registration, OIDC federated credentials, RBAC role assignments, GitHub environments (azure-deploy/azure-destroy), required secrets, and scaffold Actions workflow files. USE FOR: first-time Git-Ape setup, new subscription onboarding, multi-environment (dev/staging/prod) setup, configure OIDC, federated credentials, RBAC setup, GitHub environments, scaffold workflow files. DO NOT USE FOR: deploying resources (use git-ape), drift detection alone, secret rotation."
 metadata:
   argument-hint: "GitHub repo URL, subscription target(s), and onboarding mode (single or multi-environment)"
   user-invocable: true
@@ -18,6 +18,8 @@ This skill is the source of truth for onboarding behavior. Do not depend on a st
 - New subscription onboarding (single environment)
 - Multi-environment onboarding (dev/staging/prod across different subscriptions)
 - New user handoff where OIDC, RBAC, and GitHub environments must be created
+
+**DO NOT USE FOR:** re-deploying an already-onboarded repo (use `git-ape`), rotating or updating an existing secret or federated credential, drift detection setup alone (that is an optional sub-step covered by Step 10), or general Azure resource deployment.
 
 ## What It Configures
 
@@ -252,11 +254,14 @@ After RBAC and environment setup, ask the user about compliance requirements and
 7. Never run `git add`, `git commit`, `git push`, or open a PR for the
    scaffolded files — leave them unstaged so the user decides how to land
    them.
+8. **Idempotency on re-run:** If the skill is re-invoked after a partial failure, re-run from the last failing step — not from scratch. The Entra app, federated credentials, role assignments, and GitHub environments created before the failure are safe to reuse; do not create duplicates. Surface each already-provisioned resource as `⊝ Already exists` rather than re-creating it.
 
 ## Suggested Agent Flow
 
-1. **Run `/prereq-check`** to validate tools and auth. Stop if it doesn't report ✅ READY.
-2. Confirm target repo URL, onboarding mode, and role model.
+**First-turn rule:** the very first response to any onboarding request must be a **gated handoff** — surface prereq results and collect required inputs. It must NOT be a walkthrough, a full set of CLI commands, or a completion report. The agent must not narrate or execute onboarding steps until: (a) prereq check confirms ✅ READY, and (b) all five required inputs from step 2 are in hand.
+
+1. **Run `/prereq-check`** to validate tools and auth. Surface the full results table — tool versions, Azure CLI auth status, GitHub CLI auth status, and a ✅/❌ per check. If CLI commands cannot execute in the current environment, present the required checklist items and ask the user to confirm each one passes manually (`az` ≥ 2.50 installed and authenticated, `gh` ≥ 2.0 installed and authenticated, `jq` ≥ 1.6, `git` installed). **Never advance to step 2 until prereq results are confirmed — this is a hard gate.**
+2. **Collect the required inputs.** Ask for — and wait for answers to — at minimum: (1) target GitHub repository URL, (2) Azure subscription ID (or one per environment for multi-env), (3) RBAC role to grant (`Contributor` or `Owner`), (4) onboarding mode (`single` or `multi-environment`), (5) default branch (confirm `main` or ask if non-standard). Do not proceed to step 3 without all five.
 3. Validate current Azure/GitHub auth context (subscription, tenant, GitHub org).
 4. Ask for final confirmation.
 5. Execute the required Azure CLI and GitHub CLI commands directly from this playbook.

--- a/.github/skills/git-ape-onboarding/SKILL.md
+++ b/.github/skills/git-ape-onboarding/SKILL.md
@@ -29,6 +29,7 @@ This skill configures:
 4. GitHub environments (`azure-deploy*`, `azure-destroy`)
 5. Required GitHub secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`) and the `AZURE_SUBSCRIPTION_ID` variable
 6. Scaffolded GitHub Actions workflow files (`git-ape-plan.yml`, `-deploy.yml`, `-destroy.yml`, `-verify.yml`, `-drift.{md,lock.yml}`) and deployment standards (`.github/copilot-instructions.md`) into the user's working copy
+7. *(Optional)* The `COPILOT_GITHUB_TOKEN` repository secret that powers the agentic drift-detection workflow (`git-ape-drift.lock.yml`) — only when the user opts into scheduled drift detection
 
 ## Prerequisites
 
@@ -109,8 +110,9 @@ OIDC_PREFIX="repository_owner_id:<OWNER_ID>:repository_id:<REPO_ID>"
 7. Set GitHub repo or environment secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`) and the `AZURE_SUBSCRIPTION_ID` variable.
 8. Create GitHub environments and branch policies when permissions allow.
 9. Scaffold workflow files and deployment standards into the user's working copy (see below).
-10. Capture compliance and Azure Policy preferences (see below).
-11. Verify federated credentials, role assignments, and secrets.
+10. *(Optional)* Provision the drift detector engine credential (`COPILOT_GITHUB_TOKEN`) so the agentic drift workflow can run (see below).
+11. Capture compliance and Azure Policy preferences (see below).
+12. Verify federated credentials, role assignments, and secrets.
 
 ### Step 9: Scaffold workflow files and deployment standards
 
@@ -150,9 +152,61 @@ The helper:
   canonical template so the user can reconcile manually.
 
 If the user already had a custom `.github/copilot-instructions.md`, the
-scaffold step skips it. Step 10 (below) handles that case explicitly.
+scaffold step skips it. Step 11 (below) handles that case explicitly.
 
-### Step 10: Compliance & Azure Policy Preferences
+### Step 10: (Optional) Onboard the drift detector workflow
+
+**This step is optional.** It is only needed if the user wants the scheduled
+**drift-detection** workflow (`git-ape-drift.lock.yml`) to run. The `plan`,
+`deploy`, `destroy`, and `verify` workflows do **not** depend on anything from
+this step — skip it entirely if the user is not enabling drift detection.
+
+Unlike the other scaffolded workflows, `git-ape-drift` is a **GitHub Agentic
+Workflow** (authored with [gh-aw](https://github.github.com/gh-aw/)) that runs
+on the **GitHub Copilot engine**. Its compiled `.lock.yml` opens with a hard
+preflight gate — *"Validate COPILOT_GITHUB_TOKEN secret"* — that fails the run
+immediately when the credential is missing. There is **no fallback**: the Azure
+OIDC secrets from Step 7 cover the workflow's deterministic pre-steps, but the
+agent itself needs its own engine token.
+
+To onboard it:
+
+1. **Confirm intent.** Ask the user whether they want scheduled drift
+   detection. If not, skip this step.
+
+2. **Provision `COPILOT_GITHUB_TOKEN`** as a **repository** secret — not an
+   environment secret, because the daily `schedule` runs from `main` with no
+   environment attached:
+   ```bash
+   gh secret set COPILOT_GITHUB_TOKEN --repo <org>/<repo>
+   # paste the token when prompted — never pass it on the command line
+   ```
+   Token requirements:
+   - A GitHub **PAT** (fine-grained or classic) belonging to an identity with
+     an **active GitHub Copilot seat**.
+   - The built-in `GITHUB_TOKEN` **cannot** drive the Copilot engine, so the
+     token must be supplied explicitly.
+   - The other gh-aw tokens (`GH_AW_GITHUB_TOKEN`,
+     `GH_AW_GITHUB_MCP_SERVER_TOKEN`) are **not** required — they fall back to
+     the auto-provided `GITHUB_TOKEN`.
+
+3. **(Only if recompiling.)** The scaffolded `.lock.yml` runs as-is. The
+   `gh-aw` CLI is needed **only** when the user edits `git-ape-drift.md` and
+   wants to regenerate the lock file:
+   ```bash
+   gh extension install github/gh-aw
+   gh aw compile
+   ```
+
+4. **Smoke-test** the workflow end to end:
+   ```bash
+   gh workflow run git-ape-drift.lock.yml --repo <org>/<repo>
+   gh run list --workflow git-ape-drift.lock.yml --repo <org>/<repo> --limit 1
+   ```
+
+Never print the token value in chat output (see Safe-Execution Rules).
+
+### Step 11: Compliance & Azure Policy Preferences
 
 After RBAC and environment setup, ask the user about compliance requirements and update the `## Compliance & Azure Policy` section in `.github/copilot-instructions.md`:
 
@@ -207,9 +261,10 @@ After RBAC and environment setup, ask the user about compliance requirements and
 4. Ask for final confirmation.
 5. Execute the required Azure CLI and GitHub CLI commands directly from this playbook.
 6. Scaffold workflow files and `copilot-instructions.md` via `./scripts/scaffold-repo.sh` on macOS/Linux/WSL, or `pwsh ./scripts/scaffold-repo.ps1` on Windows (Step 9 in playbook). Report which files were created vs skipped.
-7. Ask compliance framework and enforcement mode preferences (Step 10 in playbook).
-8. Update `copilot-instructions.md` with compliance preferences — or, if the file was skipped by the scaffold step, surface the preferences in chat for manual integration.
-9. Summarize outcome (including scaffolded file counts) and suggest verification commands.
+7. *(Optional)* Offer to onboard the drift detector workflow by provisioning `COPILOT_GITHUB_TOKEN` (Step 10 in playbook). Skip if the user does not want scheduled drift detection.
+8. Ask compliance framework and enforcement mode preferences (Step 11 in playbook).
+9. Update `copilot-instructions.md` with compliance preferences — or, if the file was skipped by the scaffold step, surface the preferences in chat for manual integration.
+10. Summarize outcome (including scaffolded file counts) and suggest verification commands.
 
 ## Known Gotchas
 
@@ -270,4 +325,9 @@ gh api repos/<ORG>/<REPO> --jq '{repo_id: .id, owner_id: .owner.id}'
 
 # Validate role assignments for SP (replace principal object id)
 az role assignment list --assignee-object-id <SP_OBJECT_ID> --all -o table
+
+# (Optional, drift detector) Confirm the Copilot engine credential is set
+gh secret list --repo <ORG>/<REPO> | grep -q '^COPILOT_GITHUB_TOKEN' \
+  && echo "✅ COPILOT_GITHUB_TOKEN set" \
+  || echo "⚠️ COPILOT_GITHUB_TOKEN missing — drift workflow will fail its preflight"
 ```

--- a/.github/skills/git-ape-onboarding/templates/workflows/git-ape-verify.yml
+++ b/.github/skills/git-ape-onboarding/templates/workflows/git-ape-verify.yml
@@ -25,6 +25,7 @@ jobs:
           HAS_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID != '' }}
           HAS_TENANT_ID: ${{ secrets.AZURE_TENANT_ID != '' }}
           HAS_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID != '' }}
+          HAS_COPILOT_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN != '' }}
         run: |
           MISSING=0
 
@@ -47,6 +48,17 @@ jobs:
             MISSING=$((MISSING + 1))
           else
             echo "✅ AZURE_SUBSCRIPTION_ID is set"
+          fi
+
+          # COPILOT_GITHUB_TOKEN is OPTIONAL — only the agentic drift-detection
+          # workflow (git-ape-drift) needs it. Report as a warning and never
+          # count it toward MISSING, so plan/deploy/destroy verification still
+          # passes when drift detection is not enabled.
+          if [[ "$HAS_COPILOT_TOKEN" != "true" ]]; then
+            echo "::warning::COPILOT_GITHUB_TOKEN not set — optional, required only for the drift-detection workflow (git-ape-drift)"
+            echo "⚠️ COPILOT_GITHUB_TOKEN not set (optional — needed only for drift detection)"
+          else
+            echo "✅ COPILOT_GITHUB_TOKEN is set (drift detection enabled)"
           fi
 
           echo "missing=$MISSING" >> "$GITHUB_OUTPUT"

--- a/website/docs/getting-started/onboarding.md
+++ b/website/docs/getting-started/onboarding.md
@@ -393,6 +393,27 @@ gh variable set AZURE_SUBSCRIPTION_ID --repo "$REPO" --env "azure-destroy" --bod
 
 </details>
 
+#### (Optional) Enable drift detection
+
+The scaffolded **drift-detection** workflow (`git-ape-drift.lock.yml`) is a [GitHub Agentic Workflow](https://github.github.com/gh-aw/) that runs on the **GitHub Copilot engine**, so it needs one extra credential beyond the Azure OIDC values above: **`COPILOT_GITHUB_TOKEN`**. Its compiled workflow opens with a hard preflight gate that fails the run when the secret is missing — there is **no fallback** to the built-in `GITHUB_TOKEN`.
+
+Skip this step if you are not enabling scheduled drift detection — `plan`, `deploy`, `destroy`, and `verify` do not need it.
+
+```bash
+REPO="your-org/your-repo"
+# Paste a GitHub PAT (fine-grained or classic) from an identity with an active
+# GitHub Copilot seat. Store it as a REPOSITORY secret — the daily schedule
+# runs from main with no environment attached.
+gh secret set COPILOT_GITHUB_TOKEN -R "$REPO"
+```
+
+Confirm it end-to-end with a manual run:
+
+```bash
+gh workflow run git-ape-drift.lock.yml -R "$REPO"
+gh run list --workflow git-ape-drift.lock.yml -R "$REPO" --limit 1
+```
+
 #### Create GitHub environments
 
 <details>

--- a/website/docs/skills/git-ape-onboarding.md
+++ b/website/docs/skills/git-ape-onboarding.md
@@ -46,6 +46,7 @@ This skill configures:
 4. GitHub environments (`azure-deploy*`, `azure-destroy`)
 5. Required GitHub secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`) and the `AZURE_SUBSCRIPTION_ID` variable
 6. Scaffolded GitHub Actions workflow files (`git-ape-plan.yml`, `-deploy.yml`, `-destroy.yml`, `-verify.yml`, `-drift.{md,lock.yml}`) and deployment standards (`.github/copilot-instructions.md`) into the user's working copy
+7. *(Optional)* The `COPILOT_GITHUB_TOKEN` repository secret that powers the agentic drift-detection workflow (`git-ape-drift.lock.yml`) — only when the user opts into scheduled drift detection
 
 ## Prerequisites
 
@@ -126,8 +127,9 @@ OIDC_PREFIX="repository_owner_id:<OWNER_ID>:repository_id:<REPO_ID>"
 7. Set GitHub repo or environment secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`) and the `AZURE_SUBSCRIPTION_ID` variable.
 8. Create GitHub environments and branch policies when permissions allow.
 9. Scaffold workflow files and deployment standards into the user's working copy (see below).
-10. Capture compliance and Azure Policy preferences (see below).
-11. Verify federated credentials, role assignments, and secrets.
+10. *(Optional)* Provision the drift detector engine credential (`COPILOT_GITHUB_TOKEN`) so the agentic drift workflow can run (see below).
+11. Capture compliance and Azure Policy preferences (see below).
+12. Verify federated credentials, role assignments, and secrets.
 
 ### Step 9: Scaffold workflow files and deployment standards
 
@@ -167,9 +169,61 @@ The helper:
   canonical template so the user can reconcile manually.
 
 If the user already had a custom `.github/copilot-instructions.md`, the
-scaffold step skips it. Step 10 (below) handles that case explicitly.
+scaffold step skips it. Step 11 (below) handles that case explicitly.
 
-### Step 10: Compliance & Azure Policy Preferences
+### Step 10: (Optional) Onboard the drift detector workflow
+
+**This step is optional.** It is only needed if the user wants the scheduled
+**drift-detection** workflow (`git-ape-drift.lock.yml`) to run. The `plan`,
+`deploy`, `destroy`, and `verify` workflows do **not** depend on anything from
+this step — skip it entirely if the user is not enabling drift detection.
+
+Unlike the other scaffolded workflows, `git-ape-drift` is a **GitHub Agentic
+Workflow** (authored with [gh-aw](https://github.github.com/gh-aw/)) that runs
+on the **GitHub Copilot engine**. Its compiled `.lock.yml` opens with a hard
+preflight gate — *"Validate COPILOT_GITHUB_TOKEN secret"* — that fails the run
+immediately when the credential is missing. There is **no fallback**: the Azure
+OIDC secrets from Step 7 cover the workflow's deterministic pre-steps, but the
+agent itself needs its own engine token.
+
+To onboard it:
+
+1. **Confirm intent.** Ask the user whether they want scheduled drift
+   detection. If not, skip this step.
+
+2. **Provision `COPILOT_GITHUB_TOKEN`** as a **repository** secret — not an
+   environment secret, because the daily `schedule` runs from `main` with no
+   environment attached:
+   ```bash
+   gh secret set COPILOT_GITHUB_TOKEN --repo <org>/<repo>
+   # paste the token when prompted — never pass it on the command line
+   ```
+   Token requirements:
+   - A GitHub **PAT** (fine-grained or classic) belonging to an identity with
+     an **active GitHub Copilot seat**.
+   - The built-in `GITHUB_TOKEN` **cannot** drive the Copilot engine, so the
+     token must be supplied explicitly.
+   - The other gh-aw tokens (`GH_AW_GITHUB_TOKEN`,
+     `GH_AW_GITHUB_MCP_SERVER_TOKEN`) are **not** required — they fall back to
+     the auto-provided `GITHUB_TOKEN`.
+
+3. **(Only if recompiling.)** The scaffolded `.lock.yml` runs as-is. The
+   `gh-aw` CLI is needed **only** when the user edits `git-ape-drift.md` and
+   wants to regenerate the lock file:
+   ```bash
+   gh extension install github/gh-aw
+   gh aw compile
+   ```
+
+4. **Smoke-test** the workflow end to end:
+   ```bash
+   gh workflow run git-ape-drift.lock.yml --repo <org>/<repo>
+   gh run list --workflow git-ape-drift.lock.yml --repo <org>/<repo> --limit 1
+   ```
+
+Never print the token value in chat output (see Safe-Execution Rules).
+
+### Step 11: Compliance & Azure Policy Preferences
 
 After RBAC and environment setup, ask the user about compliance requirements and update the `## Compliance & Azure Policy` section in `.github/copilot-instructions.md`:
 
@@ -224,9 +278,10 @@ After RBAC and environment setup, ask the user about compliance requirements and
 4. Ask for final confirmation.
 5. Execute the required Azure CLI and GitHub CLI commands directly from this playbook.
 6. Scaffold workflow files and `copilot-instructions.md` via `./scripts/scaffold-repo.sh` on macOS/Linux/WSL, or `pwsh ./scripts/scaffold-repo.ps1` on Windows (Step 9 in playbook). Report which files were created vs skipped.
-7. Ask compliance framework and enforcement mode preferences (Step 10 in playbook).
-8. Update `copilot-instructions.md` with compliance preferences — or, if the file was skipped by the scaffold step, surface the preferences in chat for manual integration.
-9. Summarize outcome (including scaffolded file counts) and suggest verification commands.
+7. *(Optional)* Offer to onboard the drift detector workflow by provisioning `COPILOT_GITHUB_TOKEN` (Step 10 in playbook). Skip if the user does not want scheduled drift detection.
+8. Ask compliance framework and enforcement mode preferences (Step 11 in playbook).
+9. Update `copilot-instructions.md` with compliance preferences — or, if the file was skipped by the scaffold step, surface the preferences in chat for manual integration.
+10. Summarize outcome (including scaffolded file counts) and suggest verification commands.
 
 ## Known Gotchas
 
@@ -287,4 +342,9 @@ gh api repos/<ORG>/<REPO> --jq '{repo_id: .id, owner_id: .owner.id}'
 
 # Validate role assignments for SP (replace principal object id)
 az role assignment list --assignee-object-id <SP_OBJECT_ID> --all -o table
+
+# (Optional, drift detector) Confirm the Copilot engine credential is set
+gh secret list --repo <ORG>/<REPO> | grep -q '^COPILOT_GITHUB_TOKEN' \
+  && echo "✅ COPILOT_GITHUB_TOKEN set" \
+  || echo "⚠️ COPILOT_GITHUB_TOKEN missing — drift workflow will fail its preflight"
 ```

--- a/website/docs/skills/git-ape-onboarding.md
+++ b/website/docs/skills/git-ape-onboarding.md
@@ -1,7 +1,7 @@
 ---
 title: "Git Ape Onboarding"
 sidebar_label: "Git Ape Onboarding"
-description: "Onboard a repository, Azure subscription(s), and user identity for Git-Ape CI/CD using a skill-driven CLI playbook. Use for first-time setup of OIDC, federated credentials, RBAC, GitHub environments, and required secrets."
+description: "Bootstrap a GitHub repository for Git-Ape CI/CD: Entra app registration, OIDC federated credentials, RBAC role assignments, GitHub environments (azure-deploy/azure-destroy), required secrets, and scaffold Actions workflow files. USE FOR: first-time Git-Ape setup, new subscription onboarding, multi-environment (dev/staging/prod) setup, configure OIDC, federated credentials, RBAC setup, GitHub environments, scaffold workflow files. DO NOT USE FOR: deploying resources (use git-ape), drift detection alone, secret rotation."
 ---
 
 <!-- AUTO-GENERATED — DO NOT EDIT. Source: .github/skills/git-ape-onboarding/SKILL.md -->
@@ -9,7 +9,7 @@ description: "Onboard a repository, Azure subscription(s), and user identity for
 
 # Git Ape Onboarding
 
-> Onboard a repository, Azure subscription(s), and user identity for Git-Ape CI/CD using a skill-driven CLI playbook. Use for first-time setup of OIDC, federated credentials, RBAC, GitHub environments, and required secrets.
+> Bootstrap a GitHub repository for Git-Ape CI/CD: Entra app registration, OIDC federated credentials, RBAC role assignments, GitHub environments (azure-deploy/azure-destroy), required secrets, and scaffold Actions workflow files. USE FOR: first-time Git-Ape setup, new subscription onboarding, multi-environment (dev/staging/prod) setup, configure OIDC, federated credentials, RBAC setup, GitHub environments, scaffold workflow files. DO NOT USE FOR: deploying resources (use git-ape), drift detection alone, secret rotation.
 
 ## Details
 
@@ -35,6 +35,8 @@ This skill is the source of truth for onboarding behavior. Do not depend on a st
 - New subscription onboarding (single environment)
 - Multi-environment onboarding (dev/staging/prod across different subscriptions)
 - New user handoff where OIDC, RBAC, and GitHub environments must be created
+
+**DO NOT USE FOR:** re-deploying an already-onboarded repo (use `git-ape`), rotating or updating an existing secret or federated credential, drift detection setup alone (that is an optional sub-step covered by Step 10), or general Azure resource deployment.
 
 ## What It Configures
 
@@ -269,11 +271,14 @@ After RBAC and environment setup, ask the user about compliance requirements and
 7. Never run `git add`, `git commit`, `git push`, or open a PR for the
    scaffolded files — leave them unstaged so the user decides how to land
    them.
+8. **Idempotency on re-run:** If the skill is re-invoked after a partial failure, re-run from the last failing step — not from scratch. The Entra app, federated credentials, role assignments, and GitHub environments created before the failure are safe to reuse; do not create duplicates. Surface each already-provisioned resource as `⊝ Already exists` rather than re-creating it.
 
 ## Suggested Agent Flow
 
-1. **Run `/prereq-check`** to validate tools and auth. Stop if it doesn't report ✅ READY.
-2. Confirm target repo URL, onboarding mode, and role model.
+**First-turn rule:** the very first response to any onboarding request must be a **gated handoff** — surface prereq results and collect required inputs. It must NOT be a walkthrough, a full set of CLI commands, or a completion report. The agent must not narrate or execute onboarding steps until: (a) prereq check confirms ✅ READY, and (b) all five required inputs from step 2 are in hand.
+
+1. **Run `/prereq-check`** to validate tools and auth. Surface the full results table — tool versions, Azure CLI auth status, GitHub CLI auth status, and a ✅/❌ per check. If CLI commands cannot execute in the current environment, present the required checklist items and ask the user to confirm each one passes manually (`az` ≥ 2.50 installed and authenticated, `gh` ≥ 2.0 installed and authenticated, `jq` ≥ 1.6, `git` installed). **Never advance to step 2 until prereq results are confirmed — this is a hard gate.**
+2. **Collect the required inputs.** Ask for — and wait for answers to — at minimum: (1) target GitHub repository URL, (2) Azure subscription ID (or one per environment for multi-env), (3) RBAC role to grant (`Contributor` or `Owner`), (4) onboarding mode (`single` or `multi-environment`), (5) default branch (confirm `main` or ask if non-standard). Do not proceed to step 3 without all five.
 3. Validate current Azure/GitHub auth context (subscription, tenant, GitHub org).
 4. Ask for final confirmation.
 5. Execute the required Azure CLI and GitHub CLI commands directly from this playbook.

--- a/website/docs/skills/overview.md
+++ b/website/docs/skills/overview.md
@@ -38,7 +38,7 @@ Skills are focused capabilities invoked by agents at specific stages of the depl
 | Skill | Description | Invocable |
 |-------|-------------|:---------:|
 | [Azure Drift Detector](./azure-drift-detector) | Detect configuration drift between deployed Azure resources and stored deployment state. Compare actual Azure configuration against desired state in .azure/deployments/, identify differences, and guide user through reconciliation options. Use when checking for manual changes, policy remediations, or unauthorized modifications. | ✅ |
-| [Git Ape Onboarding](./git-ape-onboarding) | Onboard a repository, Azure subscription(s), and user identity for Git-Ape CI/CD using a skill-driven CLI playbook. Use for first-time setup of OIDC, federated credentials, RBAC, GitHub environments, and required secrets. | ✅ |
+| [Git Ape Onboarding](./git-ape-onboarding) | Bootstrap a GitHub repository for Git-Ape CI/CD: Entra app registration, OIDC federated credentials, RBAC role assignments, GitHub environments (azure-deploy/azure-destroy), required secrets, and scaffold Actions workflow files. USE FOR: first-time Git-Ape setup, new subscription onboarding, multi-environment (dev/staging/prod) setup, configure OIDC, federated credentials, RBAC setup, GitHub environments, scaffold workflow files. DO NOT USE FOR: deploying resources (use git-ape), drift detection alone, secret rotation. | ✅ |
 
 ## General Skills
 

--- a/website/docs/workflows/git-ape-verify.md
+++ b/website/docs/workflows/git-ape-verify.md
@@ -70,6 +70,7 @@ jobs:
           HAS_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID != '' }}
           HAS_TENANT_ID: ${{ secrets.AZURE_TENANT_ID != '' }}
           HAS_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID != '' }}
+          HAS_COPILOT_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN != '' }}
         run: |
           MISSING=0
 
@@ -92,6 +93,17 @@ jobs:
             MISSING=$((MISSING + 1))
           else
             echo "✅ AZURE_SUBSCRIPTION_ID is set"
+          fi
+
+          # COPILOT_GITHUB_TOKEN is OPTIONAL — only the agentic drift-detection
+          # workflow (git-ape-drift) needs it. Report as a warning and never
+          # count it toward MISSING, so plan/deploy/destroy verification still
+          # passes when drift detection is not enabled.
+          if [[ "$HAS_COPILOT_TOKEN" != "true" ]]; then
+            echo "::warning::COPILOT_GITHUB_TOKEN not set — optional, required only for the drift-detection workflow (git-ape-drift)"
+            echo "⚠️ COPILOT_GITHUB_TOKEN not set (optional — needed only for drift detection)"
+          else
+            echo "✅ COPILOT_GITHUB_TOKEN is set (drift detection enabled)"
           fi
 
           echo "missing=$MISSING" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #187

## Summary

The `/git-ape-onboarding` skill scaffolds the drift-detection workflow (`git-ape-drift.lock.yml`) but never provisions the credential it needs, so the workflow fails its first preflight gate:

```
❌ Error: None of the following secrets are set: COPILOT_GITHUB_TOKEN
```

`git-ape-drift` is a [gh-aw](https://github.github.com/gh-aw/) GitHub Agentic Workflow running on the **Copilot engine**; its compiled `.lock.yml` has a hard *"Validate COPILOT_GITHUB_TOKEN secret"* gate with **no fallback** to `GITHUB_TOKEN`. This PR makes onboarding **optionally** provision that token, as a skippable step.

## Changes

**Source**
- **`SKILL.md`** — new optional **Step 10: Onboard the drift detector workflow** (provision `COPILOT_GITHUB_TOKEN` as a *repository* secret, PAT with an active Copilot seat, gated on asking the user first). Renumbered compliance→11 / verify→12. Added to "What It Configures", Suggested Agent Flow, and Verification Commands.
- **`templates/workflows/git-ape-verify.yml`** — non-blocking `COPILOT_GITHUB_TOKEN` check: emits a `::warning::` if absent but **never** counts toward `MISSING`, so plan/deploy/destroy verification still passes when drift detection isn't enabled.

**Docs**
- **`website/docs/getting-started/onboarding.md`** — hand-written *(Optional) Enable drift detection* subsection with a smoke test.
- **`website/docs/skills/git-ape-onboarding.md`**, **`website/docs/skills/overview.md`** + **`website/docs/workflows/git-ape-verify.md`** — regenerated via `node scripts/generate-docs.js` to mirror the sources.

## Additional scope beyond #187 — onboarding agent-flow hardening (commit `aff5c52`)

Disclosing per review Finding 2. Separately from the token work, commit `aff5c52` also hardens the **behavioral quality** of the `git-ape-onboarding` skill. These are isolated in their own commit and gated by the eval suite:

1. **Frontmatter `description` rewrite** — adds explicit `USE FOR:` / `DO NOT USE FOR:` trigger phrases so the agent router fires the skill on the right intents (first-time setup, multi-env onboarding) and *not* on adjacent ones (re-deploy, secret rotation, drift-detection alone).
2. **Safe-Execution rule #8 — idempotency on re-run** — on re-invocation after a partial failure, resume from the last failing step and surface already-provisioned resources as `⊝ Already exists` instead of creating duplicate Entra apps / federated credentials / role assignments.
3. **"Suggested Agent Flow" rewrite** — adds a first-turn gated handoff (must surface prereq results + collect inputs, not a walkthrough), enumerates the 5 mandatory inputs (repo URL, subscription ID, RBAC role, mode, branch), and makes the prereq check a hard gate.

**Why keep them here:** they are framework-aligned trigger-precision + safe-execution improvements to the same skill this PR already edits, and they move the onboarding eval **0.68 → 0.70 (+0.016)** overall, **+0.064** on first-time repo setup, green across all 4 models. Per reviewer's offer ("disclose or split"), keeping them in-PR and disclosing here.

## Review follow-ups

- **Finding 1 (stale doc mirror) — fixed.** Re-ran `node scripts/generate-docs.js`; committed only the two onboarding pages (`git-ape-onboarding.md`, `overview.md`) that the final `SKILL.md` requires. The unrelated gh-aw `v0.78.3 → v0.79.8` lock-doc churn (`daily-repo-status`, `issue-triage`) is left out, keeping PR scope clean.
- **Finding 2 (undisclosed scope) — disclosed** in the section above.

## Validation
- `actionlint` passes clean on the edited `git-ape-verify.yml` template.
- Docs regenerated with the repo generator; trailing-newline state of `SKILL.md` preserved.
- `git-ape-onboarding` evals green across all 4 models.

## Note on scope
The generator also re-touches two **unrelated** lock docs (`daily-repo-status-lock.md`, `issue-triage-agent-lock.md`) — pre-existing staleness (lock files already at gh-aw setup `v0.79.8`, committed docs at `v0.78.3`). Those are reverted to keep this PR focused. The `Docs Check` workflow is advisory/non-blocking and may flag them; happy to fold those regenerations in if preferred.
