### PR TITLE
ci(waza): qualify and pin waza v0.37.0

### DIFF
--- a/.github/workflows/waza-agent-evals.yml
+++ b/.github/workflows/waza-agent-evals.yml
@@ -66,7 +66,7 @@ concurrency:
 # `releases/latest` endpoint returns whichever was published last, which has
 # bitten PR #109 with a 404 on the wrong asset.
 env:
-  WAZA_VERSION: 'v0.33.0'
+  WAZA_VERSION: 'v0.37.0'
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/waza-evals.yml
+++ b/.github/workflows/waza-evals.yml
@@ -72,7 +72,7 @@ concurrency:
 # `releases/latest` endpoint returns whichever was published last, which has
 # bitten PR #109 with a 404 on the wrong asset.
 env:
-  WAZA_VERSION: 'v0.33.0'
+  WAZA_VERSION: 'v0.37.0'
 
 # Note: there is no top-level skill list. The canonical list lives in
 # .github/evals/manifest.yaml and is read by the `prepare` job below.

--- a/website/docs/workflows/waza-agent-evals.md
+++ b/website/docs/workflows/waza-agent-evals.md
@@ -144,7 +144,7 @@ concurrency:
 # `releases/latest` endpoint returns whichever was published last, which has
 # bitten PR #109 with a 404 on the wrong asset.
 env:
-  WAZA_VERSION: 'v0.33.0'
+  WAZA_VERSION: 'v0.37.0'
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/website/docs/workflows/waza-evals.md
+++ b/website/docs/workflows/waza-evals.md
@@ -150,7 +150,7 @@ concurrency:
 # `releases/latest` endpoint returns whichever was published last, which has
 # bitten PR #109 with a 404 on the wrong asset.
 env:
-  WAZA_VERSION: 'v0.33.0'
+  WAZA_VERSION: 'v0.37.0'
 
 # Note: there is no top-level skill list. The canonical list lives in
 # .github/evals/manifest.yaml and is read by the `prepare` job below.


### PR DESCRIPTION
## Summary

Bumps the pinned waza release from **v0.33.0 → v0.37.0** in both eval workflows and their mirrored docs, after qualifying that 0.37 eval behavior still matches our baselines.

This is a 4-line change (the `WAZA_VERSION` env pin), but it was made deliberately per the workflow policy: *"Bump deliberately after validating that the new version's eval behavior still matches our baselines."*

## Files changed
- `.github/workflows/waza-evals.yml`
- `.github/workflows/waza-agent-evals.yml`
- `website/docs/workflows/waza-evals.md`
- `website/docs/workflows/waza-agent-evals.md`

## Qualification (run locally against this repo with the 0.37.0 binary)

waza jumped 0.33 → 0.37 (internal 0.34/0.35/0.36), so I validated everything the pipelines depend on:

- **Binary**: `waza-darwin-arm64` + `linux-amd64` (CI) publish at `v0.37.0`; SHA256 checksum verified.
- **CLI surface (0.33→0.37)**: additive only — new `update` command, `run --auto-file-issue`, and `--workers` default now `auto`. Every command/flag both workflows use (`run --model/--judge-model/--suggest/--recommend/--baseline/--format/--output/--reporter/--parallel`, `tokens compare/count/profile`, `check`, `quality`) is unchanged.
- **Schemas**: `.waza.yaml`, all `eval.yaml`, and task files pass 0.37 `waza check` schema validation.
- **Real `waza run`** (`prereq-check`, cheap model): produced `github-comment` markdown, junit XML, and `--output` JSON. The CI jq detector `.tasks[].runs[].error_msg` (session-not-found) still returns 0 cleanly; the new per-trial `usage` field ([microsoft/waza#277](https://github.com/microsoft/waza/pull/277)) is purely additive.
- **`waza tokens`** JSON and **`waza quality`** table outputs unchanged.
- **actionlint** clean on both workflows.

## Notes
- The devcontainer installs `latest` (now 0.37.0) — left as-is by design; CI stays explicitly pinned.
- No agent evals exist yet, so `waza-agent-evals.yml` still no-ops; the bump keeps it aligned.
- CHANGELOG is auto-generated from commits, so it's untouched here.