### PR TITLE
fix: copy .well-known to build output (ARD catalog 404)

### DIFF
--- a/.github/workflows/git-ape-docs.yml
+++ b/.github/workflows/git-ape-docs.yml
@@ -47,6 +47,9 @@ jobs:
         working-directory: website
         run: npm run build
 
+      - name: Copy hidden static dirs (Docusaurus skips dotfiles)
+        run: cp -r website/static/.well-known website/build/.well-known
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
## Problem

`https://azure.github.io/git-ape/.well-known/ai-catalog.json` returns 404 even though PR #220 was merged and the Docs Deploy workflow succeeded.

**Root cause:** Docusaurus 3 skips hidden directories (dotfiles like \.well-known\) when copying \static/\ to \uild/\. The file exists at \website/static/.well-known/ai-catalog.json\ but never makes it into the deployed artifact.

**Evidence:**
- \https://azure.github.io/git-ape/img/logo.svg\ → 200 ✅ (non-hidden static dir)
- \https://azure.github.io/git-ape/.well-known/ai-catalog.json\ → 404 ❌ (hidden dir skipped by Docusaurus)

## Fix

Add an explicit \cp\ step after the Docusaurus build to copy the \.well-known\ directory into the build output before it is uploaded to GitHub Pages.

\\\yaml
- name: Copy hidden static dirs (Docusaurus skips dotfiles)
  run: cp -r website/static/.well-known website/build/.well-known
\\\

## Testing

After merge, verify the catalog is live:
\\\
curl -I https://azure.github.io/git-ape/.well-known/ai-catalog.json
# Expected: HTTP/2 200
\\\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>