### PR TITLE
fix(pages): publish .well-known via include-hidden-files

### DIFF
--- a/.github/workflows/git-ape-docs.yml
+++ b/.github/workflows/git-ape-docs.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
+          include-hidden-files: true
 
   deploy:
     environment:


### PR DESCRIPTION
This applies the same fix proven in git-ape-private:

- set `include-hidden-files: true` on `actions/upload-pages-artifact@v5`

Why:
- GitHub Pages deployment currently succeeds but dot paths are not served.
- `/.well-known/ai-catalog.json` and `/.nojekyll` remain 404.

Expected result after merge:
- `https://azure.github.io/git-ape/.well-known/ai-catalog.json` returns 200
- `https://azure.github.io/git-ape/.nojekyll` returns 200

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
